### PR TITLE
Potential fix for code scanning alert no. 18: Server-side request forgery

### DIFF
--- a/packages/emberharmony/src/cli/cmd/github.ts
+++ b/packages/emberharmony/src/cli/cmd/github.ts
@@ -776,15 +776,32 @@ export const GithubRunCommand = cmd({
         const matches = [...mdMatches, ...tagMatches].sort((a, b) => a.index - b.index)
         console.log("Images", JSON.stringify(matches, null, 2))
 
+        const toAllowedAttachmentUrl = (raw: string): string | null => {
+          try {
+            const parsed = new URL(raw)
+            if (parsed.protocol !== "https:") return null
+            if (parsed.hostname !== "github.com") return null
+            if (!parsed.pathname.startsWith("/user-attachments/")) return null
+            return parsed.toString()
+          } catch {
+            return null
+          }
+        }
+
         let offset = 0
         for (const m of matches) {
           const tag = m[0]
           const url = m[1]
           const start = m.index
-          const filename = path.basename(url)
+          const safeUrl = toAllowedAttachmentUrl(url)
+          if (!safeUrl) {
+            console.error(`Skipping non-allowed attachment URL: ${url}`)
+            continue
+          }
+          const filename = path.basename(new URL(safeUrl).pathname)
 
           // Download image
-          const res = await fetch(url, {
+          const res = await fetch(safeUrl, {
             headers: {
               Authorization: `Bearer ${appToken}`,
               Accept: "application/vnd.github.v3+json",

--- a/packages/emberharmony/src/cli/cmd/github.ts
+++ b/packages/emberharmony/src/cli/cmd/github.ts
@@ -793,12 +793,13 @@ export const GithubRunCommand = cmd({
           const tag = m[0]
           const url = m[1]
           const start = m.index
-          const safeUrl = toAllowedAttachmentUrl(url)
-          if (!safeUrl) {
+          const safeUrlObj = toAllowedAttachmentUrl(url)
+          if (!safeUrlObj) {
             console.error(`Skipping non-allowed attachment URL: ${url}`)
             continue
           }
-          const filename = path.basename(new URL(safeUrl).pathname)
+          const safeUrl = safeUrlObj.toString()
+          const filename = path.basename(safeUrlObj.pathname)
 
           // Download image
           const res = await fetch(safeUrl, {

--- a/packages/emberharmony/src/cli/cmd/github.ts
+++ b/packages/emberharmony/src/cli/cmd/github.ts
@@ -776,13 +776,13 @@ export const GithubRunCommand = cmd({
         const matches = [...mdMatches, ...tagMatches].sort((a, b) => a.index - b.index)
         console.log("Images", JSON.stringify(matches, null, 2))
 
-        const toAllowedAttachmentUrl = (raw: string): string | null => {
+        const toAllowedAttachmentUrl = (raw: string): URL | null => {
           try {
             const parsed = new URL(raw)
             if (parsed.protocol !== "https:") return null
             if (parsed.hostname !== "github.com") return null
             if (!parsed.pathname.startsWith("/user-attachments/")) return null
-            return parsed.toString()
+            return parsed
           } catch {
             return null
           }


### PR DESCRIPTION
Potential fix for [https://github.com/SolaceHarmony/emberharmony/security/code-scanning/18](https://github.com/SolaceHarmony/emberharmony/security/code-scanning/18)

General fix: parse tainted URL input with `URL`, then enforce strict allowlist checks on protocol, hostname, and pathname before issuing any request. Only fetch when validation succeeds; otherwise skip with a warning.

Best targeted fix in `packages/emberharmony/src/cli/cmd/github.ts`:
- Add a small local helper (near this logic) to validate and canonicalize attachment URLs.
- In the loop, validate `m[1]` before calling `fetch`.
- Use the validated/canonical URL string for both `path.basename(...)` and `fetch(...)`.
- Keep existing behavior (still processing valid GitHub user-attachments links), while blocking malformed or unexpected URLs.

No new dependency is required; use built-in `URL`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
