### PR TITLE
Potential fix for code scanning alert no. 17: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/packages/emberharmony/src/plugin/codex.ts
+++ b/packages/emberharmony/src/plugin/codex.ts
@@ -28,10 +28,20 @@ async function generatePKCE(): Promise<PkceCodes> {
 
 function generateRandomString(length: number): string {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-  const bytes = crypto.getRandomValues(new Uint8Array(length))
-  return Array.from(bytes)
-    .map((b) => chars[b % chars.length])
-    .join("")
+  const charLen = chars.length
+  const maxValid = Math.floor(256 / charLen) * charLen
+  const result: string[] = []
+
+  while (result.length < length) {
+    const bytes = crypto.getRandomValues(new Uint8Array(length - result.length))
+    for (const b of bytes) {
+      if (b >= maxValid) continue
+      result.push(chars[b % charLen])
+      if (result.length === length) break
+    }
+  }
+
+  return result.join("")
 }
 
 function base64UrlEncode(buffer: ArrayBuffer): string {


### PR DESCRIPTION
Potential fix for [https://github.com/SolaceHarmony/emberharmony/security/code-scanning/17](https://github.com/SolaceHarmony/emberharmony/security/code-scanning/17)

To fix this without changing intended functionality, replace modulo mapping with **rejection sampling** so each character index is uniformly distributed.

Best approach in this file:
- Keep the same PKCE character set and output length.
- In `generateRandomString(length)`, repeatedly draw random bytes and only accept bytes `< maxValid`, where `maxValid = floor(256 / chars.length) * chars.length`.
- Convert accepted bytes to indices via `% chars.length` and append until desired length is reached.

This preserves behavior (same charset, same output length, still CSPRNG-backed) while removing bias.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
