### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-zed-extension.yml
+++ b/.github/workflows/sync-zed-extension.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   zed:
     name: Release Zed Extension


### PR DESCRIPTION
Potential fix for [https://github.com/SolaceHarmony/emberharmony/security/code-scanning/23](https://github.com/SolaceHarmony/emberharmony/security/code-scanning/23)

Add an explicit `permissions` block at the workflow root so all jobs (including `zed`) inherit least-privilege defaults. For this workflow, the best non-breaking baseline is:

- `contents: read`

This supports checkout/read operations while preventing unnecessary write scopes for `GITHUB_TOKEN`. Since the workflow appears to use PAT secrets for external/write actions, restricting `GITHUB_TOKEN` should not change intended functionality.

Change needed:
- File: `.github/workflows/sync-zed-extension.yml`
- Region: after the `on:` triggers block and before `jobs:`
- No imports, methods, or extra definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
