### PR TITLE
Potential fix for code scanning alert no. 19: Uncontrolled command line

### DIFF
--- a/packages/emberharmony/src/lsp/server.ts
+++ b/packages/emberharmony/src/lsp/server.ts
@@ -948,6 +948,10 @@ export namespace LSPServer {
         log.error("clangd release did not include a tag name")
         return
       }
+      if (!/^[0-9A-Za-z._-]+$/.test(tag)) {
+        log.error("clangd release tag contains unsupported characters", { tag })
+        return
+      }
       const platform = process.platform
       const tokens: Record<string, string> = {
         darwin: "mac",


### PR DESCRIPTION
Potential fix for [https://github.com/SolaceHarmony/emberharmony/security/code-scanning/19](https://github.com/SolaceHarmony/emberharmony/security/code-scanning/19)

To fix this without changing intended functionality, validate the release `tag` against a strict allowlist format before using it in filesystem paths or process execution. This keeps legitimate clangd tags working (for example `18.1.8`) while preventing path traversal or path-shaping characters.

Best fix in this file:
- In `packages/emberharmony/src/lsp/server.ts`, immediately after `const tag = release.tag_name` and null-check, add a regex validation such as `/^[0-9A-Za-z._-]+$/`.
- If invalid, log an error and return early.
- Keep the rest of the logic unchanged.

This requires no new imports or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
