### PR TITLE
Repair publish workflow gates for main-as-default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ permissions:
 jobs:
   version:
     runs-on: ubuntu-latest
-    if: github.ref_name == 'dev' || github.event_name == 'release'
+    if: github.ref_name == 'main' || github.event_name == 'release'
     outputs:
       version: ${{ steps.version.outputs.version || steps.version-release.outputs.version }}
-      release: ${{ steps.version-release.outputs.release }}
+      release: ${{ steps.version.outputs.release || steps.version-release.outputs.release }}
       tag: ${{ steps.version.outputs.tag || steps.version-release.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
   build-cli:
     needs: version
     runs-on: ubuntu-latest
-    if: github.ref_name == 'dev' || github.event_name == 'release'
+    if: github.ref_name == 'main' || github.event_name == 'release'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,7 +92,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
 
   build-tauri:
-    if: github.ref_name == 'dev' || github.event_name == 'release'
+    if: github.ref_name == 'main' || github.event_name == 'release'
     needs:
       - build-cli
       - version


### PR DESCRIPTION
## Summary
- Switch the three publish-job `if:` gates from `github.ref_name == 'dev'` to `'main'`. With main as the new default branch, dispatched publishes were silently skipping every job.
- Coalesce `needs.version.outputs.release` across both version steps so the dispatch path (where `version.ts` writes `release=<id>` from `gh release view`) populates it. Previously only the release-event path was wired through, leaving the tauri-action `releaseId:` input empty on dispatched publishes.

## Test plan
- [ ] Workflow Dispatch from `main` triggers `version` -> `build-cli` -> `build-tauri` -> `publish` (jobs no longer skipped).
- [ ] Published GitHub Release still triggers the same pipeline; tag-vs-`packages/emberharmony/package.json` verification still fires.
- [ ] On a dispatched run, `tauri-action` receives a non-empty `releaseId` and attaches desktop bundles to the draft release created by `version.ts`.
