### PR TITLE
ci: reusable build workflow + per-merge CI + CodeQL

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,224 @@
+name: build
+run-name: build ${{ inputs.version }}${{ inputs.release != '' && format(' (release {0})', inputs.release) || '' }}
+
+# Reusable workflow that produces the CLI binaries and Tauri desktop bundles.
+# Called by:
+#   - ci.yml     (post-merge verification on dev/main; uploads workflow artifacts only)
+#   - publish.yml (release publish; uploads artifacts AND attaches to GitHub release draft)
+#
+# When inputs.release and inputs.tag are empty strings, tauri-action skips
+# release attachment and only produces workflow artifacts. See:
+# https://github.com/tauri-apps/tauri-action#workflow-inputs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Semver version string the artifacts should carry."
+        type: string
+        required: true
+      release:
+        description: "GitHub release ID to attach artifacts to. Empty = workflow artifacts only."
+        type: string
+        default: ""
+      tag:
+        description: "Git tag name for the release (e.g. v1.2.3). Empty in CI."
+        type: string
+        default: ""
+      publish-name:
+        description: "Scoped npm package name embedded in the CLI build."
+        type: string
+        default: "@thesolaceproject/emberharmony"
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  build-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Build
+        id: build
+        run: |
+          ./packages/emberharmony/script/build.ts
+        env:
+          EMBERHARMONY_RELEASE: ${{ inputs.release }}
+          EMBERHARMONY_PUBLISH_NAME: ${{ inputs.publish-name }}
+          GH_TOKEN: ${{ github.token }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: emberharmony-cli
+          path: packages/emberharmony/dist
+
+  build-tauri:
+    needs: build-cli
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-latest
+            target: x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.settings.host }}
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+
+      - uses: apple-actions/import-codesign-certs@v7
+        if: ${{ runner.os == 'macOS' && env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
+        with:
+          keychain: build
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Verify Certificate
+        if: ${{ runner.os == 'macOS' && env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+            echo "CERT_ID=$APPLE_SIGNING_IDENTITY" >> "$GITHUB_ENV"
+
+            TEAM_ID=$(echo "$APPLE_SIGNING_IDENTITY" | sed -n 's/.*(\([A-Z0-9]\{10\}\)).*/\1/p')
+            if [ -n "${TEAM_ID:-}" ]; then
+              echo "APPLE_TEAM_ID=$TEAM_ID" >> "$GITHUB_ENV"
+              echo "Using APPLE_TEAM_ID from signing identity: $TEAM_ID"
+            fi
+
+            echo "Using APPLE_SIGNING_IDENTITY override."
+            security find-identity -v -p codesigning build.keychain | cat
+            exit 0
+          fi
+
+          CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application" | head -n 1 || true)
+          if [ -z "$CERT_INFO" ]; then
+            echo "No 'Developer ID Application' identity found in build.keychain" >&2
+            security find-identity -v -p codesigning build.keychain | cat
+            exit 1
+          fi
+
+          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+          echo "CERT_ID=$CERT_ID" >> "$GITHUB_ENV"
+          echo "Certificate imported: $CERT_ID"
+
+          TEAM_ID=$(echo "$CERT_ID" | sed -n 's/.*(\([A-Z0-9]\{10\}\)).*/\1/p')
+          if [ -n "${TEAM_ID:-}" ]; then
+            echo "APPLE_TEAM_ID=$TEAM_ID" >> "$GITHUB_ENV"
+            echo "Detected APPLE_TEAM_ID from certificate: $TEAM_ID"
+          fi
+
+      - name: Setup Apple API Key
+        if: ${{ runner.os == 'macOS' && env.APPLE_API_KEY_PATH != '' }}
+        run: |
+          printf '%s' "${{ secrets.APPLE_API_KEY_PATH }}" > "$RUNNER_TEMP/apple-api-key.p8"
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Cache apt packages
+        if: contains(matrix.settings.host, 'ubuntu')
+        uses: actions/cache@v5
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: ${{ runner.os }}-${{ matrix.settings.target }}-apt-${{ hashFiles('.github/workflows/_build.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.settings.target }}-apt-
+
+      - name: install dependencies (ubuntu only)
+        if: contains(matrix.settings.host, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.settings.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/desktop/src-tauri
+          shared-key: ${{ matrix.settings.target }}
+
+      - name: Prepare
+        run: |
+          cd packages/desktop
+          bun ./scripts/prepare.ts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUST_TARGET: ${{ matrix.settings.target }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      # Fixes AppImage build issues, can be removed when https://github.com/tauri-apps/tauri/pull/12491 is released
+      - name: Install tauri-cli from portable appimage branch
+        if: contains(matrix.settings.host, 'ubuntu')
+        run: |
+          cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
+          echo "Installed tauri-cli version:"
+          cargo tauri --version
+
+      - name: Export Apple ID notarization credentials
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          APPLE_ID="${{ secrets.APPLE_ID }}"
+          APPLE_PASSWORD="${{ secrets.APPLE_PASSWORD }}"
+
+          if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_PASSWORD:-}" ]; then
+            echo "Apple ID notarization not configured; using App Store Connect API key."
+            exit 0
+          fi
+
+          echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"
+          echo "APPLE_PASSWORD=$APPLE_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Build and upload artifacts
+        uses: tauri-apps/tauri-action@v0.6
+        timeout-minutes: 60
+        if: ${{ runner.os != 'macOS' || (env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '') }}
+        with:
+          projectPath: packages/desktop
+          uploadWorkflowArtifacts: true
+          tauriScript: ${{ (contains(matrix.settings.host, 'ubuntu') && 'cargo tauri') || '' }}
+          args: --target ${{ matrix.settings.target }} --config ./src-tauri/tauri.prod.conf.json --verbose
+          updaterJsonPreferNsis: true
+          # Release attachment: when both releaseId and tagName are empty (CI mode),
+          # tauri-action skips the release upload and only emits workflow artifacts.
+          releaseId: ${{ inputs.release }}
+          tagName: ${{ inputs.tag }}
+          releaseDraft: true
+          releaseAssetNamePattern: emberharmony-desktop-[platform]-[arch][ext]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: true
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.p8
+          APPLE_TEAM_ID: ${{ env.APPLE_TEAM_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+run-name: ci ${{ github.ref_name }} @ ${{ github.sha }}
+
+# Verification builds. Runs the full 5-target CLI + Tauri matrix on every push
+# to an integration branch (i.e. after a PR merges). Does NOT run on pull_request
+# — that keeps the expensive matrix off PR review and away from fork secrets.
+
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+# Every merge commit deserves its own verification — do not cancel in progress.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        run: echo "version=0.0.0-ci.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: version
+    uses: ./.github/workflows/_build.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      # release and tag intentionally left empty — _build.yml will produce
+      # workflow artifacts only, no GitHub release attachment.
+    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+run-name: codeql ${{ github.ref_name }} @ ${{ github.sha }}
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Weekly catch-all so dormant branches still get scanned. Monday 04:23 UTC.
+    - cron: "23 4 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # javascript-typescript covers the whole TS/JS codebase (CLI, web, console, ui, etc).
+        # actions scans .github/workflows/** for secret-handling and injection bugs —
+        # relevant given this repo's prior fork-PR-secret incident (see commit 5569e76).
+        # Rust CodeQL is still experimental; the Tauri Rust surface is small enough to skip.
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,210 +59,28 @@ jobs:
         id: version-release
         if: github.event_name == 'release'
         run: |
-          echo "version=${{ steps.release-version.outputs.version }}" >> "$GITHUB_OUTPUT"
-          echo "tag=${{ steps.release-version.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          echo "release=${{ github.event.release.id }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=${{ steps.release-version.outputs.version }}"
+            echo "tag=${{ steps.release-version.outputs.tag }}"
+            echo "release=${{ github.event.release.id }}"
+          } >> "$GITHUB_OUTPUT"
 
-  build-cli:
+  build:
     needs: version
-    runs-on: ubuntu-latest
     if: github.ref_name == 'main' || github.event_name == 'release'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-tags: true
-
-      - uses: ./.github/actions/setup-bun
-
-      - name: Build
-        id: build
-        run: |
-          ./packages/emberharmony/script/build.ts
-        env:
-          EMBERHARMONY_RELEASE: ${{ needs.version.outputs.release }}
-          EMBERHARMONY_PUBLISH_NAME: "@thesolaceproject/emberharmony"
-          GH_TOKEN: ${{ github.token }}
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: emberharmony-cli
-          path: packages/emberharmony/dist
-
-    outputs:
+    uses: ./.github/workflows/_build.yml
+    with:
       version: ${{ needs.version.outputs.version }}
-
-  build-tauri:
-    if: github.ref_name == 'main' || github.event_name == 'release'
-    needs:
-      - build-cli
-      - version
-    continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - host: macos-latest
-            target: x86_64-apple-darwin
-          - host: macos-latest
-            target: aarch64-apple-darwin
-          - host: windows-latest
-            target: x86_64-pc-windows-msvc
-          - host: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-          - host: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.settings.host }}
-    env:
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-tags: true
-
-      - uses: apple-actions/import-codesign-certs@v7
-        if: ${{ runner.os == 'macOS' && env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
-        with:
-          keychain: build
-          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
-          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-
-      - name: Verify Certificate
-        if: ${{ runner.os == 'macOS' && env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
-            echo "CERT_ID=$APPLE_SIGNING_IDENTITY" >> "$GITHUB_ENV"
-
-            TEAM_ID=$(echo "$APPLE_SIGNING_IDENTITY" | sed -n 's/.*(\([A-Z0-9]\{10\}\)).*/\1/p')
-            if [ -n "${TEAM_ID:-}" ]; then
-              echo "APPLE_TEAM_ID=$TEAM_ID" >> "$GITHUB_ENV"
-              echo "Using APPLE_TEAM_ID from signing identity: $TEAM_ID"
-            fi
-
-            echo "Using APPLE_SIGNING_IDENTITY override."
-            security find-identity -v -p codesigning build.keychain | cat
-            exit 0
-          fi
-
-          CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application" | head -n 1 || true)
-          if [ -z "$CERT_INFO" ]; then
-            echo "No 'Developer ID Application' identity found in build.keychain" >&2
-            security find-identity -v -p codesigning build.keychain | cat
-            exit 1
-          fi
-
-          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
-          echo "CERT_ID=$CERT_ID" >> "$GITHUB_ENV"
-          echo "Certificate imported: $CERT_ID"
-
-          TEAM_ID=$(echo "$CERT_ID" | sed -n 's/.*(\([A-Z0-9]\{10\}\)).*/\1/p')
-          if [ -n "${TEAM_ID:-}" ]; then
-            echo "APPLE_TEAM_ID=$TEAM_ID" >> "$GITHUB_ENV"
-            echo "Detected APPLE_TEAM_ID from certificate: $TEAM_ID"
-          fi
-
-      - name: Setup Apple API Key
-        if: ${{ runner.os == 'macOS' && env.APPLE_API_KEY_PATH != '' }}
-        run: |
-          printf '%s' "${{ secrets.APPLE_API_KEY_PATH }}" > "$RUNNER_TEMP/apple-api-key.p8"
-
-      - uses: ./.github/actions/setup-bun
-
-      - name: Cache apt packages
-        if: contains(matrix.settings.host, 'ubuntu')
-        uses: actions/cache@v5
-        with:
-          path: /var/cache/apt/archives/*.deb
-          key: ${{ runner.os }}-${{ matrix.settings.target }}-apt-${{ hashFiles('.github/workflows/publish.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.settings.target }}-apt-
-
-      - name: install dependencies (ubuntu only)
-        if: contains(matrix.settings.host, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-          targets: ${{ matrix.settings.target }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/desktop/src-tauri
-          shared-key: ${{ matrix.settings.target }}
-
-      - name: Prepare
-        run: |
-          cd packages/desktop
-          bun ./scripts/prepare.ts
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          RUST_TARGET: ${{ matrix.settings.target }}
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-
-      # Fixes AppImage build issues, can be removed when https://github.com/tauri-apps/tauri/pull/12491 is released
-      - name: Install tauri-cli from portable appimage branch
-        if: contains(matrix.settings.host, 'ubuntu')
-        run: |
-          cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
-          echo "Installed tauri-cli version:"
-          cargo tauri --version
-
-      - name: Export Apple ID notarization credentials
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          APPLE_ID="${{ secrets.APPLE_ID }}"
-          APPLE_PASSWORD="${{ secrets.APPLE_PASSWORD }}"
-
-          if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_PASSWORD:-}" ]; then
-            echo "Apple ID notarization not configured; using App Store Connect API key."
-            exit 0
-          fi
-
-          echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"
-          echo "APPLE_PASSWORD=$APPLE_PASSWORD" >> "$GITHUB_ENV"
-
-      - name: Build and upload artifacts
-        uses: tauri-apps/tauri-action@v0.6
-        timeout-minutes: 60
-        if: ${{ runner.os != 'macOS' || (env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '') }}
-        with:
-          projectPath: packages/desktop
-          uploadWorkflowArtifacts: true
-          tauriScript: ${{ (contains(matrix.settings.host, 'ubuntu') && 'cargo tauri') || '' }}
-          args: --target ${{ matrix.settings.target }} --config ./src-tauri/tauri.prod.conf.json --verbose
-          updaterJsonPreferNsis: true
-          releaseId: ${{ needs.version.outputs.release }}
-          tagName: ${{ needs.version.outputs.tag }}
-          releaseDraft: true
-          releaseAssetNamePattern: emberharmony-desktop-[platform]-[arch][ext]
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: true
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.p8
-          APPLE_TEAM_ID: ${{ env.APPLE_TEAM_ID }}
+      release: ${{ needs.version.outputs.release }}
+      tag: ${{ needs.version.outputs.tag }}
+      publish-name: "@thesolaceproject/emberharmony"
+    secrets: inherit
 
   publish:
     if: github.repository == 'SolaceHarmony/emberharmony'
     needs:
       - version
-      - build-cli
-      - build-tauri
+      - build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,196 @@
+# Building EmberHarmony
+
+This document covers the build pipeline: how artifacts are produced locally, in CI, and at release time. For day-to-day development (`bun dev`, running the API/web/desktop apps) see [CONTRIBUTING.md](./CONTRIBUTING.md). For macOS code signing and notarization specifics, see [APPLE.md](./APPLE.md).
+
+## Artifacts
+
+EmberHarmony ships two artifacts:
+
+1. **CLI binary** — `emberharmony` (`.exe` on Windows). Cross-compiled from TypeScript using `Bun.build({ compile: ... })`. Produced for 11 platform/variant combinations.
+2. **Tauri desktop app** — native installer/bundle that wraps the web UI and embeds the CLI binary as a Tauri sidecar. Five platform targets.
+
+## Build paths
+
+There are three ways the build runs, all driven by the same two underlying scripts.
+
+| Path | Trigger | Entry | Output |
+|---|---|---|---|
+| **Local desktop** | `bun desktop:build` from repo root | `packages/desktop/scripts/build-local.ts` | Signed `.app` + `.dmg` (macOS), `.msi`/`.nsis` (Windows), `.deb`/`.rpm`/`.AppImage` (Linux) under `packages/desktop/src-tauri/target/release/bundle/` |
+| **Local CLI only** | `./packages/emberharmony/script/build.ts --single` | Same script, single-platform mode | `packages/emberharmony/dist/emberharmony-<platform>/bin/emberharmony` |
+| **CI verification** | Push to `main` or `dev` | `.github/workflows/ci.yml` → `_build.yml` | Workflow artifacts (CLI dist + desktop bundles per platform) |
+| **Release** | `gh workflow run publish.yml` or GitHub release event | `.github/workflows/publish.yml` → `_build.yml` | npm publish + GitHub release with attached desktop installers |
+
+## Local builds
+
+### CLI binary
+
+For your current platform only:
+
+```bash
+./packages/emberharmony/script/build.ts --single
+```
+
+Output: `packages/emberharmony/dist/emberharmony-<platform>/bin/emberharmony` (e.g. `emberharmony-darwin-arm64`).
+
+To cross-compile for all 11 targets (slow, used in CI):
+
+```bash
+./packages/emberharmony/script/build.ts
+```
+
+### Desktop app
+
+From repo root:
+
+```bash
+bun desktop:build              # Full build with bundling (DMG on macOS, etc.)
+bun desktop:build:nodmg        # Skip macOS DMG packaging
+```
+
+`build-local.ts` orchestrates the pipeline:
+
+1. Load `.env` from repo root (for Apple signing/notarization creds).
+2. Build the CLI binary (`script/build.ts --single`), unless `EMBERHARMONY_SKIP_CLI=1`.
+3. Copy the CLI binary into `packages/desktop/src-tauri/sidecars/` for Tauri to embed.
+4. Run `cargo tauri build` with platform-appropriate bundle list. macOS DMG is skipped here because Tauri's upstream `bundle_dmg.sh` is broken.
+5. On macOS, manually create the installer DMG via `hdiutil`, then `codesign` it if `APPLE_SIGNING_IDENTITY` is set.
+
+Prerequisites: Bun 1.3+, Rust stable, Tauri prerequisites for your OS (see https://v2.tauri.app/start/prerequisites/).
+
+## CI build pipeline
+
+### Reusable workflow: `.github/workflows/_build.yml`
+
+The build is defined once and called by two workflows. `_build.yml` is a `workflow_call` workflow that takes:
+
+- `version` (required) — semver string the artifacts carry
+- `release` (default `""`) — GitHub release ID to attach artifacts to
+- `tag` (default `""`) — git tag name for the release
+
+When `release` and `tag` are empty, `tauri-action` produces workflow artifacts only — no release attachment. When both are set, it uploads to the specified GitHub release draft.
+
+Two jobs:
+
+- **`build-cli`** (ubuntu-latest) — runs `./packages/emberharmony/script/build.ts` to cross-compile the CLI for all 11 targets in one Linux job. Uploads `emberharmony-cli` artifact.
+- **`build-tauri`** (matrix) — depends on `build-cli`. Downloads the CLI artifact, runs `packages/desktop/scripts/prepare.ts` to stage the sidecar and inject updater keys, then `tauri-apps/tauri-action@v0.6` builds the platform bundle.
+
+### Matrix
+
+| Host | Target | Output |
+|---|---|---|
+| `macos-latest` | `x86_64-apple-darwin` | `.app`/`.dmg` Intel |
+| `macos-latest` | `aarch64-apple-darwin` | `.app`/`.dmg` Apple Silicon |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `.nsis`/`.msi` |
+| `ubuntu-24.04` | `x86_64-unknown-linux-gnu` | `.deb`/`.rpm`/`.AppImage` |
+| `ubuntu-24.04-arm` | `aarch64-unknown-linux-gnu` | `.deb`/`.rpm`/`.AppImage` |
+
+### Verification builds: `ci.yml`
+
+Triggers:
+
+- `push` to `main` or `dev` (i.e. after a PR merges into an integration branch)
+- `workflow_dispatch` (manual re-run from the Actions UI)
+
+Notably, **not** `pull_request`. That keeps the expensive matrix off PR review, prevents fork code from being executed with secrets, and bounds Actions-minute spend to merge rate rather than push rate.
+
+If a merge-triggered run fails, re-run it from the Actions UI via `workflow_dispatch` without making another commit.
+
+### Release publish: `publish.yml`
+
+Triggers:
+
+- `workflow_dispatch` from the Actions UI (preferred for normal releases)
+- `release` event (`types: [published]`) when a GitHub release is created
+
+Job flow:
+
+1. **`version`** — computes the next version. On `workflow_dispatch`, `./script/version.ts` does the bump and creates a draft release. On a release event, the tag's version must match `packages/emberharmony/package.json` or the job fails fast.
+2. **`build`** — calls `_build.yml` with the computed `version`, `release` ID, and `tag`. Same 11-CLI + 5-Tauri matrix as CI, but artifacts attach to the release draft.
+3. **`publish`** — runs `./script/publish.ts` to publish `@thesolaceproject/emberharmony` (and the 11 platform npm packages) to npmjs.org, then promotes the GitHub release from draft to published.
+
+To cut a release:
+
+```bash
+gh workflow run publish.yml
+# follow the version prompts in ./script/version.ts when it runs
+```
+
+## Signing and notarization
+
+Signing is enabled per-platform when the relevant secrets are set on the repo. All signing steps gracefully no-op when secrets are missing — useful for fork PRs and local builds.
+
+### macOS
+
+| Secret | Purpose |
+|---|---|
+| `APPLE_CERTIFICATE` | base64-encoded Developer ID Application `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | password for the `.p12` |
+| `APPLE_SIGNING_IDENTITY` | (optional) explicit signing identity string, e.g. `Developer ID Application: Org Name (TEAMID)` |
+| `APPLE_API_ISSUER` + `APPLE_API_KEY` + `APPLE_API_KEY_PATH` | App Store Connect API key (preferred notarization auth) |
+| `APPLE_ID` + `APPLE_PASSWORD` + `APPLE_TEAM_ID` | Apple ID + app-specific password (fallback notarization auth) |
+
+`APPLE_TEAM_ID` is auto-derived from the signing identity by parsing the `(TEAMID)` suffix when not explicitly set. See [APPLE.md](./APPLE.md) for the full notarization flow.
+
+### Tauri updater
+
+Signs the update manifests so the auto-updater accepts them.
+
+| Secret | Purpose |
+|---|---|
+| `TAURI_SIGNING_PRIVATE_KEY` | Tauri updater private key |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | password for the private key |
+
+### npm publish
+
+| Secret | Purpose |
+|---|---|
+| `NPM_TOKEN` | npmjs.org automation token with publish rights on `@thesolaceproject` |
+
+### Listing what's set
+
+```bash
+gh secret list
+```
+
+Returns names only — secret values can never be read back.
+
+## CodeQL
+
+`.github/workflows/codeql.yml` runs CodeQL on push to `main`/`dev`, on PRs to those branches, and weekly on Monday at 04:23 UTC. Two language groups are scanned:
+
+- **`javascript-typescript`** — the entire TS/JS codebase.
+- **`actions`** — scans `.github/workflows/**` for secret-handling and injection bugs. Worth keeping after the prior fork-PR-secret incident (commit `5569e76`).
+
+This replaces GitHub's "default setup" CodeQL. The workflow file gives explicit control over languages, paths, and schedule.
+
+> [!IMPORTANT]
+> If you re-enable "Default setup" in repo Settings → Code security, it will conflict with `codeql.yml`. Pick one.
+
+## Workflow files reference
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/_build.yml` | Reusable build workflow. Builds CLI + Tauri matrix. |
+| `.github/workflows/ci.yml` | Post-merge verification on `main`/`dev`. Calls `_build.yml`. |
+| `.github/workflows/publish.yml` | Release pipeline. Calls `_build.yml`, then publishes to npm + GitHub release. |
+| `.github/workflows/codeql.yml` | Security analysis on TS/JS and workflow files. |
+| `.github/workflows/test.yml` | Test suite (Bun) on PRs. |
+| `.github/workflows/typecheck.yml` | `bun turbo typecheck` on push + PRs. |
+
+## Useful commands
+
+```bash
+# What is actually being run on GitHub?
+gh workflow list
+gh workflow view ci.yml
+gh run list --workflow=ci.yml
+
+# Validate workflow syntax locally
+actionlint .github/workflows/*.yml
+
+# Trigger a CI run on the current branch from your laptop
+gh workflow run ci.yml --ref <branch>
+
+# Cut a release
+gh workflow run publish.yml
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,9 @@ Then run it with:
 
 Replace `<platform>` with your platform (e.g., `darwin-arm64`, `linux-x64`).
 
+> [!NOTE]
+> For the full build pipeline — local desktop builds, CI verification, release publishing, and the matrix/signing details — see [BUILDING.md](./BUILDING.md).
+
 - Core pieces:
   - `packages/emberharmony`: EmberHarmony core business logic & server.
   - `packages/emberharmony/src/cli/cmd/tui/`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://discord.gg/EdF8f7JR"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
   <a href="https://www.npmjs.com/package/@thesolaceproject/emberharmony"><img alt="npm" src="https://img.shields.io/npm/v/%40thesolaceproject%2Femberharmony?style=flat-square" /></a>
-  <a href="https://github.com/SolaceHarmony/emberharmony/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/SolaceHarmony/emberharmony/publish.yml?style=flat-square&branch=dev" /></a>
+  <a href="https://github.com/SolaceHarmony/emberharmony/actions/workflows/ci.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/SolaceHarmony/emberharmony/ci.yml?style=flat-square&branch=main" /></a>
 </p>
 
 [![EmberHarmony Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://github.com/SolaceHarmony/emberharmony)


### PR DESCRIPTION
## Summary

- Extract `build-cli` + `build-tauri` from `publish.yml` into `_build.yml` as a reusable workflow callable via `workflow_call`.
- Add `ci.yml`: per-merge verification on push to `main`/`dev`. No `pull_request` trigger, so fork code never sees secrets and Actions minutes are not burned on every WIP push.
- Add `codeql.yml`: committed CodeQL workflow (replaces default setup). Scans `javascript-typescript` and `actions` (catches secret-handling and injection bugs in workflow files; cf. 5569e76).
- Refactor `publish.yml` to delegate build jobs to `_build.yml` via `workflow_call`, keeping the `version` and `publish` jobs in place.
- Add `BUILDING.md` covering all build paths (local desktop, local CLI, CI verification, release publish), the reusable-workflow architecture, the 5-target matrix, and the signing/notarization secret chain. CONTRIBUTING.md gets a pointer to it.
- Fix `README.md` build-status badge: now points at `ci.yml` on `main` (the workflow that actually fires) instead of `publish.yml` on `dev` (dispatch-only, never updates).

When `_build.yml` is called with empty `release` and `tag` inputs, `tauri-action` produces workflow artifacts only with no release attachment. When called with both set (from `publish.yml`), it attaches to the GitHub release draft. One canonical build definition, two callers.

## Cost

Full 5-target matrix (macOS x64/arm64, Windows x64, Linux x64/arm64) on every merge to `main`/`dev`. Estimate ~300-500 billable minutes per merge (macOS at 10x multiplier). Frequency bounded by merge rate, not push rate. `Swatinem/rust-cache` already wired in.

## Before merging

- [ ] Disable **Code scanning > Default setup** in repo Settings, otherwise `codeql.yml` conflicts.

## Test plan

- [ ] CI workflow does not appear in PR checks (only `typecheck` + `test` should run on this PR).
- [ ] After merge to `main`, `ci` workflow fires and the 5-target Tauri matrix completes.
- [ ] `actionlint .github/workflows/*.yml` exits clean (verified locally).
- [ ] `gh workflow run publish.yml` still works end-to-end (manual smoke test after merge).
- [ ] CodeQL alerts appear in Security tab within ~10 min of first successful run.
- [ ] README build-status badge becomes a green check (or red X) after the first `ci.yml` run on `main`.
