### PR TITLE
Add Rust CodeQL coverage with buildless extraction

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: CodeQL Advanced
 run-name: codeql ${{ github.ref_name }} @ ${{ github.sha }}
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,8 +29,15 @@ jobs:
         # javascript-typescript covers the whole TS/JS codebase (CLI, web, console, ui, etc).
         # actions scans .github/workflows/** for secret-handling and injection bugs —
         # relevant given this repo's prior fork-PR-secret incident (see commit 5569e76).
-        # Rust CodeQL is still experimental; the Tauri Rust surface is small enough to skip.
-        language: [javascript-typescript, actions]
+        # rust covers the Tauri desktop surface (packages/desktop/src-tauri).
+        # build-mode none = buildless extraction; no cargo build or system libs required.
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+          - language: rust
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,6 +46,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
Resolves the duplicate CodeQL configuration (repo default-setup + advanced `codeql.yml` were both active and conflicting).

- Add a `rust` entry to the analyze matrix so the advanced config matches default setup's language coverage (`packages/desktop/src-tauri`). Default setup scanned actions/js-ts/rust; `codeql.yml` only scanned js-ts + actions, so disabling default setup would have silently dropped Rust analysis.
- Use `build-mode: none` (CodeQL buildless extraction) for Rust — no cargo build or system libs (libwebkit2gtk etc.) needed in CI.
- Switch the matrix to `include` form so `build-mode` can be set per language.

After this merges, repo **default code-scanning setup will be disabled** so only this advanced workflow runs (no more duplicate scans / rejected SARIF uploads).

## Test plan
- [ ] PR triggers `Analyze (javascript-typescript)`, `Analyze (actions)`, and `Analyze (rust)` — all green.
- [ ] Rust analysis completes without a build step (build-mode none).
- [ ] After default-setup is disabled, only the `codeql.yml` scans appear in the Actions tab / code-scanning alerts.
