### PR TITLE
Rename test workflow to 'Tests'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
-name: test
+name: Tests
+run-name: tests ${{ github.ref_name }} @ ${{ github.sha }}
 
 on:
   pull_request:
@@ -6,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    name: test (${{ matrix.settings.name }})
+    name: Tests (${{ matrix.settings.name }})
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
Rename the `test` workflow to `Tests` so it matches the Title Case style of the other workflows (`CI`, `Build`, `Publish`, `CodeQL Advanced`) and reads clearly in the Actions tab.

- Top-level `name: test` -> `name: Tests`.
- Job label `test (<os>)` -> `Tests (<os>)`.
- Add a `run-name` for consistency with `CI` / `CodeQL Advanced`.

Not a removal: this workflow is the only thing running the actual test suites (`bun turbo test` on linux, Playwright `test:e2e:local` on windows). `ci.yml` only does verification builds, so the two are complementary.

## Note
No branch protection currently references the old `test (linux)` / `test (windows)` check names, so renaming won't orphan a required status check. If/when we add branch protection, point required checks at `Tests (linux)` / `Tests (windows)`.

## Test plan
- [ ] PR shows `Tests (linux)` and `Tests (windows)` checks, both green.
