### PR TITLE
Harden version sync & publish: fail-loud over silent fallbacks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [dev, main]
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests (${{ matrix.settings.name }})

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,6 +6,9 @@ on:
     branches: [dev, main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/packages/emberharmony/script/publish.ts
+++ b/packages/emberharmony/script/publish.ts
@@ -31,7 +31,7 @@ await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 
 const meta = await Bun.file(path.join(root, "package.json"))
   .json()
-  .catch(() => ({}) as unknown)
+  .catch(() => ({}) as Record<string, unknown>)
 
 const description =
   typeof meta === "object" && meta && "description" in meta && typeof meta.description === "string"

--- a/packages/emberharmony/script/publish.ts
+++ b/packages/emberharmony/script/publish.ts
@@ -29,35 +29,31 @@ await $`mkdir -p ./dist/${pkg.name}`
 await $`cp -r ./bin ./dist/${pkg.name}/bin`
 await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 
-const meta = await Bun.file(path.join(root, "package.json"))
-  .json()
-  .catch(() => ({}) as Record<string, unknown>)
+// The published manifest is derived from the repo-root package.json. A failed
+// read or a missing field is a real misconfiguration, so surface it instead of
+// publishing a package with silently-dropped metadata.
+const meta = (await Bun.file(path.join(root, "package.json")).json()) as Record<string, unknown>
 
-const description =
-  typeof meta === "object" && meta && "description" in meta && typeof meta.description === "string"
-    ? meta.description
-    : undefined
+const requireString = (key: string): string => {
+  const value = meta[key]
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`root package.json is missing a valid "${key}" string`)
+  }
+  return value
+}
+const requireMeta = (key: string): unknown => {
+  const value = meta[key]
+  if (value == null) {
+    throw new Error(`root package.json is missing required field "${key}"`)
+  }
+  return value
+}
 
-const homepage =
-  typeof meta === "object" && meta && "homepage" in meta && typeof meta.homepage === "string"
-    ? meta.homepage
-    : undefined
-
-const license =
-  typeof meta === "object" && meta && "license" in meta && typeof meta.license === "string" ? meta.license : "MIT"
-
-const repository =
-  typeof meta === "object" &&
-  meta &&
-  "repository" in meta &&
-  (typeof meta.repository === "object" || typeof meta.repository === "string")
-    ? meta.repository
-    : undefined
-
-const bugs =
-  typeof meta === "object" && meta && "bugs" in meta && (typeof meta.bugs === "object" || typeof meta.bugs === "string")
-    ? meta.bugs
-    : undefined
+const description = requireString("description")
+const homepage = requireString("homepage")
+const license = requireString("license")
+const repository = requireMeta("repository")
+const bugs = requireMeta("bugs")
 
 await Bun.file(`./dist/${pkg.name}/package.json`).write(
   JSON.stringify(

--- a/script/sync-version.ts
+++ b/script/sync-version.ts
@@ -33,10 +33,12 @@ for await (const rel of new Glob("**/package.json").scan({ cwd: ROOT })) {
   }
   const file = path.join(ROOT, rel)
   const text = await Bun.file(file).text()
-  // Only touch a package's own top-level "version" field; dependency specifiers
-  // use a different shape ("name": "1.2.3") and are never matched here.
-  if (!/"version":\s*"[^"]*"/.test(text)) continue
-  const next = text.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`)
+  // Only touch a package's own top-level "version" field. Anchoring to a
+  // two-space indent at line start ensures we never match a nested "version"
+  // key (deeper indentation) inside scripts/dependencies/etc.
+  const TOP_LEVEL_VERSION = /^( {2}"version":\s*)"[^"]*"/m
+  if (!TOP_LEVEL_VERSION.test(text)) continue
+  const next = text.replace(TOP_LEVEL_VERSION, `$1"${version}"`)
   if (next !== text) {
     await Bun.write(file, next)
     updated.push(rel)

--- a/script/sync-version.ts
+++ b/script/sync-version.ts
@@ -24,6 +24,7 @@ const SKIP = ["packages/sdk/js/package.json", "sdks/vscode/package.json"]
 
 const updated: string[] = []
 const skipped: string[] = []
+const noVersion: string[] = []
 
 for await (const rel of new Glob("**/package.json").scan({ cwd: ROOT })) {
   if (rel.includes("node_modules") || rel.includes("/dist") || rel.includes("/.output/")) continue
@@ -33,11 +34,28 @@ for await (const rel of new Glob("**/package.json").scan({ cwd: ROOT })) {
   }
   const file = path.join(ROOT, rel)
   const text = await Bun.file(file).text()
-  // Only touch a package's own top-level "version" field. Anchoring to a
-  // two-space indent at line start ensures we never match a nested "version"
-  // key (deeper indentation) inside scripts/dependencies/etc.
+
+  // Authoritatively decide whether this package carries its own version by
+  // parsing it: a nested "version" (inside scripts/dependencies/etc.) is never
+  // a top-level key, so it can't be mistaken for the package's own version.
+  // A malformed package.json throws here rather than being silently skipped.
+  const parsed = JSON.parse(text) as { version?: unknown }
+  if (!("version" in parsed)) {
+    noVersion.push(rel)
+    continue
+  }
+
+  // The package has a top-level version. Rewrite it in place with a
+  // format-preserving replace targeting a two-space-indented line. If that
+  // pattern doesn't match, the file uses unexpected formatting — fail loudly
+  // instead of silently leaving its version out of sync.
   const TOP_LEVEL_VERSION = /^( {2}"version":\s*)"[^"]*"/m
-  if (!TOP_LEVEL_VERSION.test(text)) continue
+  if (!TOP_LEVEL_VERSION.test(text)) {
+    throw new Error(
+      `${rel} has a top-level "version" key that is not a two-space-indented line; ` +
+        `reformat it or update sync-version.ts rather than silently skipping it`,
+    )
+  }
   const next = text.replace(TOP_LEVEL_VERSION, `$1"${version}"`)
   if (next !== text) {
     await Bun.write(file, next)
@@ -49,3 +67,4 @@ console.log(`version.json → ${version}`)
 console.log(`updated ${updated.length} package.json file(s):`)
 for (const r of updated.sort()) console.log(`  ${r}`)
 if (skipped.length) console.log(`skipped (independently versioned): ${skipped.join(", ")}`)
+if (noVersion.length) console.log(`no top-level version (left untouched): ${noVersion.sort().join(", ")}`)


### PR DESCRIPTION
## Summary

Follow-up to PR #62 review. Two of the original review fixes left silent fallbacks in place — this replaces them with fail-loud validation, on the principle that a misconfiguration should stop the build and point at the problem rather than be quietly papered over.

## Changes

- **`script/sync-version.ts`** — parse each `package.json` to authoritatively detect a *top-level* `version` (a nested `version` in scripts/deps can no longer be mistaken for it). Malformed JSON throws; a top-level `version` with unexpected formatting throws instead of silently drifting out of sync; genuinely versionless packages are now **reported** rather than quietly skipped.
- **`packages/emberharmony/script/publish.ts`** — drop the `.catch(() => ({}))` fallback on the root `package.json` read and the per-field defensive defaults. A failed read or a missing `description`/`homepage`/`license`/`repository`/`bugs` now throws instead of publishing dropped metadata or a silently-defaulted `"MIT"` license. Supersedes the earlier `Record<string, unknown>` typing band-aid.
- The least-privilege CI `permissions: contents: read` from the original review commit is retained.

## Test plan

- [x] `tsgo --noEmit` passes for `packages/emberharmony`
- [x] `bun run script/sync-version.ts` runs with no spurious writes; reports skipped + versionless files
- [x] Unit-tested both changes' core logic (11 cases): malformed JSON throws, nested-only version skipped without corruption, top-level synced, wrong-indent throws, missing/empty publish fields throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)