### PR TITLE
Remove upstream PR template; lock CI out of default-token writes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-### What does this PR do?
-
-Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.
-
-**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**
-
-### How did you verify your code works?

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -22,10 +22,9 @@ on:
         type: string
         default: "@thesolaceproject/emberharmony"
 
-# Permissions are inherited from the caller: ci.yml grants read, and
-# publish.yml grants write so the CLI build can upload release assets via
-# `gh release upload`. A reusable workflow cannot exceed its caller's grant,
-# so jobs do not declare permissions here.
+# Permissions are inherited from the caller. Both callers grant read-only:
+# this build never mutates the repository (no commit, tag, push, or release
+# upload). The CLI binaries are surfaced solely as workflow artifacts below.
 
 jobs:
   build-cli:
@@ -48,7 +47,6 @@ jobs:
           EMBERHARMONY_RELEASE: ${{ inputs.release }}
           EMBERHARMONY_TAG: ${{ inputs.tag }}
           EMBERHARMONY_PUBLISH_NAME: ${{ inputs.publish-name }}
-          GH_TOKEN: ${{ github.token }}
 
       - name: Upload CLI artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,13 @@
 name: Publish
 run-name: ${{ github.event.release.tag_name }}
 
-# Publishing is driven solely by a published GitHub release. Cut a release with a
-# tag like v1.3.0; the release id and tag flow straight from the github.event
-# context into the build — no CI step parses or validates the version (the tag is
-# trusted), and nothing here commits, tags, or pushes.
+# Publishing is driven solely by a published GitHub release (a human cuts the
+# release and its tag from the GitHub UI — CI never creates tags or releases).
+# The default GITHUB_TOKEN stays read-only per enterprise policy. The single
+# repository write — attaching the built binaries to the human-created release —
+# is performed by the attach-assets job below using RELEASE_ASSETS_TOKEN, a
+# fine-grained PAT scoped to contents:write on this repository only. The npm
+# publish targets the external npm registry and uses NPM_TOKEN.
 on:
   release:
     types: [published]
@@ -12,7 +15,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 jobs:
@@ -24,8 +27,35 @@ jobs:
       publish-name: "@thesolaceproject/emberharmony"
     secrets: inherit
 
-  # npm publish runs for STABLE releases only. A pre-release still builds and
-  # uploads CLI assets to the GitHub release via the build job above, but never
+  # The one sanctioned repository write: attach the built archives to the release
+  # the human cut. Runs for stable releases AND pre-releases (a dev build still
+  # ships its binaries on the release page). Deliberately does not use the
+  # workflow's GITHUB_TOKEN — RELEASE_ASSETS_TOKEN is a fine-grained PAT with
+  # contents:write on this repo only. build.ts itself has no upload capability,
+  # so compromising the build cannot publish anything.
+  attach-assets:
+    if: ${{ github.repository == 'SolaceHarmony/emberharmony' }}
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: emberharmony-cli
+          path: dist
+
+      - name: Attach archives to release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ASSETS_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          ls -la dist
+          gh release upload "$TAG" dist/*.tar.gz dist/*.zip dist/*.sha256 \
+            --clobber --repo "${{ github.repository }}"
+
+  # npm publish runs for STABLE releases only. A pre-release still builds the CLI
+  # binaries and attaches them to the release via attach-assets, but never
   # touches npm.
   publish:
     if: ${{ github.repository == 'SolaceHarmony/emberharmony' && !github.event.release.prerelease }}
@@ -68,7 +98,6 @@ jobs:
           EMBERHARMONY_RELEASE: ${{ github.event.release.id }}
           EMBERHARMONY_PUBLISH_NAME: "@thesolaceproject/emberharmony"
           EMBERHARMONY_PUBLISH_PLATFORMS: "1"
-          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -207,12 +207,9 @@ if (Script.release) {
       await Bun.write(`./dist/${releaseName}.zip.sha256`, hash + "\n")
     }
   }
-  // Upload the CLI archives as a separate set of assets on the release the user cut.
-  // EMBERHARMONY_TAG is the actual release tag (stable v1.3.0 or a pre-release like
-  // v1.3.0-dev.1); fall back to the static version for local/manual runs. Bun's $
-  // escapes the interpolated tag as a single argument, so it is injection-safe.
-  const releaseTag = process.env.EMBERHARMONY_TAG || `v${Script.version}`
-  await $`gh release upload ${releaseTag} ./dist/*.zip ./dist/*.tar.gz ./dist/*.sha256 --clobber`
+  // The archives above are produced for distribution but are NOT uploaded from
+  // here: this build is not permitted to mutate GitHub. CI exposes them as
+  // workflow artifacts; attaching them to a release is a human step.
 }
 
 export { binaries }


### PR DESCRIPTION
## Summary

Enterprise policy: GitHub Actions must not mutate the repository through the default token, and releases/tags are exclusively human-created. This PR enforces that while keeping binaries shipping to the release page.

## Changes

- **Delete `.github/pull_request_template.md`** — upstream leftover.
- **`build.ts` can no longer release** — the `gh release upload` call is removed; the script only builds binaries and archives. Compromising the build script no longer grants a publish path.
- **`_build.yml`** — `GH_TOKEN` removed from the build step; the build runs tokenless and surfaces `dist/` as a workflow artifact.
- **`publish.yml`** — workflow `permissions` downgraded to `contents: read`. New `attach-assets` job performs the single sanctioned write (attaching archives to the human-created release) using **`RELEASE_ASSETS_TOKEN`** — a fine-grained PAT scoped to `contents: write` on this repo only — instead of the workflow token. Runs for both stable and pre-releases. Unused `GITHUB_TOKEN` removed from the npm step.
- **`test.yml`** — redundant explicit checkout token removed.

## Setup required before next release

Create a fine-grained PAT (this repo only, permission: *Contents: Read and write*) and add it as the `RELEASE_ASSETS_TOKEN` repo secret. Until it exists, `attach-assets` will fail loudly — by design, no silent fallback to the default token.

## Test plan

- [x] YAML validated; `tsgo --noEmit` passes for `packages/emberharmony`
- [x] No `github.token` / `GITHUB_TOKEN` / `contents: write` left in any workflow (outside comments)
- [ ] Cut a test pre-release after merge + secret setup to verify attach-assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)