### PR TITLE
Merge dev into main: human-controlled releases, tag-driven artifacts, CI write lockdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-### What does this PR do?
-
-Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.
-
-**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**
-
-### How did you verify your code works?

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -14,7 +14,15 @@ on:
         type: string
         default: ""
       tag:
-        description: "Git tag name for the release (e.g. v1.2.3). Empty in CI."
+        description: "Git tag name for the release (e.g. v1.2.3). Sculpts the archive filenames. Empty in CI."
+        type: string
+        default: ""
+      target:
+        description: "Branch the release targets (main or dev). Determines the channel. Empty in CI."
+        type: string
+        default: ""
+      release-notes:
+        description: "Human-written release notes, bundled into each archive as RELEASE_NOTES.md. Optional."
         type: string
         default: ""
       publish-name:
@@ -46,6 +54,8 @@ jobs:
         env:
           EMBERHARMONY_RELEASE: ${{ inputs.release }}
           EMBERHARMONY_TAG: ${{ inputs.tag }}
+          EMBERHARMONY_TARGET: ${{ inputs.target }}
+          EMBERHARMONY_RELEASE_NOTES: ${{ inputs.release-notes }}
           EMBERHARMONY_PUBLISH_NAME: ${{ inputs.publish-name }}
 
       - name: Upload CLI artifacts

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -22,10 +22,9 @@ on:
         type: string
         default: "@thesolaceproject/emberharmony"
 
-# Permissions are inherited from the caller: ci.yml grants read, and
-# publish.yml grants write so the CLI build can upload release assets via
-# `gh release upload`. A reusable workflow cannot exceed its caller's grant,
-# so jobs do not declare permissions here.
+# Permissions are inherited from the caller. Both callers grant read-only:
+# this build never mutates the repository (no commit, tag, push, or release
+# upload). The CLI binaries are surfaced solely as workflow artifacts below.
 
 jobs:
   build-cli:
@@ -48,7 +47,6 @@ jobs:
           EMBERHARMONY_RELEASE: ${{ inputs.release }}
           EMBERHARMONY_TAG: ${{ inputs.tag }}
           EMBERHARMONY_PUBLISH_NAME: ${{ inputs.publish-name }}
-          GH_TOKEN: ${{ github.token }}
 
       - name: Upload CLI artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,11 @@ jobs:
     with:
       release: ${{ github.event.release.id }}
       tag: ${{ github.event.release.tag_name }}
+      # The branch the human picked as the release target in the GitHub UI.
+      # main → stable ("latest"), dev → dev channel; the build fails on
+      # anything else.
+      target: ${{ github.event.release.target_commitish }}
+      release-notes: ${{ github.event.release.body }}
       publish-name: "@thesolaceproject/emberharmony"
     secrets: inherit
 
@@ -54,11 +59,11 @@ jobs:
           gh release upload "$TAG" dist/*.tar.gz dist/*.zip dist/*.sha256 \
             --clobber --repo "${{ github.repository }}"
 
-  # npm publish runs for STABLE releases only. A pre-release still builds the CLI
-  # binaries and attaches them to the release via attach-assets, but never
-  # touches npm.
+  # npm publish runs ONLY for stable releases targeting main. A dev-target or
+  # pre-release build still ships binaries to the release page via
+  # attach-assets, but never touches npm.
   publish:
-    if: ${{ github.repository == 'SolaceHarmony/emberharmony' && !github.event.release.prerelease }}
+    if: ${{ github.repository == 'SolaceHarmony/emberharmony' && !github.event.release.prerelease && github.event.release.target_commitish == 'main' }}
     needs:
       - build
     runs-on: ubuntu-latest
@@ -96,6 +101,7 @@ jobs:
       - run: ./script/publish.ts
         env:
           EMBERHARMONY_RELEASE: ${{ github.event.release.id }}
+          EMBERHARMONY_TARGET: ${{ github.event.release.target_commitish }}
           EMBERHARMONY_PUBLISH_NAME: "@thesolaceproject/emberharmony"
           EMBERHARMONY_PUBLISH_PLATFORMS: "1"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,13 @@
 name: Publish
 run-name: ${{ github.event.release.tag_name }}
 
-# Publishing is driven solely by a published GitHub release. Cut a release with a
-# tag like v1.3.0; the release id and tag flow straight from the github.event
-# context into the build — no CI step parses or validates the version (the tag is
-# trusted), and nothing here commits, tags, or pushes.
+# Publishing is driven solely by a published GitHub release (a human cuts the
+# release and its tag from the GitHub UI — CI never creates tags or releases).
+# The default GITHUB_TOKEN stays read-only per enterprise policy. The single
+# repository write — attaching the built binaries to the human-created release —
+# is performed by the attach-assets job below using RELEASE_ASSETS_TOKEN, a
+# fine-grained PAT scoped to contents:write on this repository only. The npm
+# publish targets the external npm registry and uses NPM_TOKEN.
 on:
   release:
     types: [published]
@@ -12,7 +15,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 jobs:
@@ -24,8 +27,35 @@ jobs:
       publish-name: "@thesolaceproject/emberharmony"
     secrets: inherit
 
-  # npm publish runs for STABLE releases only. A pre-release still builds and
-  # uploads CLI assets to the GitHub release via the build job above, but never
+  # The one sanctioned repository write: attach the built archives to the release
+  # the human cut. Runs for stable releases AND pre-releases (a dev build still
+  # ships its binaries on the release page). Deliberately does not use the
+  # workflow's GITHUB_TOKEN — RELEASE_ASSETS_TOKEN is a fine-grained PAT with
+  # contents:write on this repo only. build.ts itself has no upload capability,
+  # so compromising the build cannot publish anything.
+  attach-assets:
+    if: ${{ github.repository == 'SolaceHarmony/emberharmony' }}
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: emberharmony-cli
+          path: dist
+
+      - name: Attach archives to release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ASSETS_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          ls -la dist
+          gh release upload "$TAG" dist/*.tar.gz dist/*.zip dist/*.sha256 \
+            --clobber --repo "${{ github.repository }}"
+
+  # npm publish runs for STABLE releases only. A pre-release still builds the CLI
+  # binaries and attaches them to the release via attach-assets, but never
   # touches npm.
   publish:
     if: ${{ github.repository == 'SolaceHarmony/emberharmony' && !github.event.release.prerelease }}
@@ -68,7 +98,6 @@ jobs:
           EMBERHARMONY_RELEASE: ${{ github.event.release.id }}
           EMBERHARMONY_PUBLISH_NAME: "@thesolaceproject/emberharmony"
           EMBERHARMONY_PUBLISH_PLATFORMS: "1"
-          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,28 @@ permissions:
   actions: read
 
 jobs:
+  # A release targeting dev that is not marked as a pre-release would become
+  # GitHub's /releases/latest — the target of every stable curl install and
+  # update check — so a single missed checkbox would ship dev binaries to
+  # stable users. Refuse to build it.
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dev-target releases to be pre-releases
+        env:
+          TARGET: ${{ github.event.release.target_commitish }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          if [ "$TARGET" = "dev" ] && [ "$PRERELEASE" != "true" ]; then
+            echo "::error::Release targets dev but is not marked as a pre-release. Delete the release, recreate it with the pre-release checkbox set, and try again."
+            exit 1
+          fi
+          echo "release target=$TARGET prerelease=$PRERELEASE — ok"
+
   build:
+    needs:
+      - validate
     uses: ./.github/workflows/_build.yml
     with:
       release: ${{ github.event.release.id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/install
+++ b/install
@@ -195,6 +195,16 @@ else
         fi
     fi
 
+    # The tag becomes part of filenames and URLs — refuse anything that could
+    # traverse paths or smuggle shell/URL syntax (same rule as build.ts).
+    # Must run BEFORE the tag is interpolated into any URL or path.
+    validate_tag() {
+        if [[ ! "$1" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo -e "${RED}Error: Release tag '$1' contains unsafe characters${NC}"
+            exit 1
+        fi
+    }
+
     # Resolve the release tag, then sculpt the asset filename from it
     # (e.g. v2.3.0 -> emberharmony-v2.3.0-linux-x64.tar.gz). Tags are used
     # verbatim — releases older than the tag-named scheme cannot be installed
@@ -206,8 +216,10 @@ else
             echo -e "${RED}Failed to fetch the latest release tag from GitHub${NC}"
             exit 1
         fi
+        validate_tag "$release_tag"
     else
         release_tag=$requested_tag
+        validate_tag "$release_tag"
 
         # Verify the release exists before downloading
         http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/SolaceHarmony/emberharmony/releases/tag/${release_tag}")

--- a/install
+++ b/install
@@ -15,18 +15,25 @@ Usage: install.sh [options]
 
 Options:
     -h, --help              Display this help message
-    -v, --version <version> Install a specific version (e.g., 1.0.180)
+    -t, --tag <tag>         Install a specific GitHub release tag (e.g., v2.3.0)
     -b, --binary <path>     Install from a local binary instead of downloading
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
     curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/dev/install | bash
-    curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/dev/install | bash -s -- --version 1.0.180
+    curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/dev/install | bash -s -- --tag v2.3.0
     ./install --binary /path/to/emberharmony
 EOF
 }
 
-requested_version=${VERSION:-}
+# Releases are identified by their GitHub release tag, used verbatim. The
+# legacy VERSION interface is gone: versions live inside the binary
+# (version.json) and never name a release.
+if [ -n "${VERSION:-}" ]; then
+    echo -e "${RED}Error: VERSION is no longer supported; releases are addressed by tag. Use TAG=<release tag> (e.g. TAG=v2.3.0)${NC}"
+    exit 1
+fi
+requested_tag=${TAG:-}
 no_modify_path=false
 binary_path=""
 
@@ -37,11 +44,15 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         -v|--version)
+            echo -e "${RED}Error: --version is no longer supported; releases are addressed by tag. Use --tag <release tag> (e.g. --tag v2.3.0)${NC}"
+            exit 1
+            ;;
+        -t|--tag)
             if [[ -n "${2:-}" ]]; then
-                requested_version="$2"
+                requested_tag="$2"
                 shift 2
             else
-                echo -e "${RED}Error: --version requires a version argument${NC}"
+                echo -e "${RED}Error: --tag requires a release tag argument${NC}"
                 exit 1
             fi
             ;;
@@ -172,9 +183,6 @@ else
       target="$target-musl"
     fi
 
-    filename="$APP-$target$archive_ext"
-
-
     if [ "$os" = "linux" ]; then
         if ! command -v tar >/dev/null 2>&1; then
              echo -e "${RED}Error: 'tar' is required but not installed.${NC}"
@@ -187,28 +195,32 @@ else
         fi
     fi
 
-    if [ -z "$requested_version" ]; then
-        url="https://github.com/SolaceHarmony/emberharmony/releases/latest/download/$filename"
-        specific_version=$(curl -s https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+    # Resolve the release tag, then sculpt the asset filename from it
+    # (e.g. v2.3.0 -> emberharmony-v2.3.0-linux-x64.tar.gz). Tags are used
+    # verbatim — releases older than the tag-named scheme cannot be installed
+    # with this script.
+    if [ -z "$requested_tag" ]; then
+        release_tag=$(curl -s https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 
-        if [[ $? -ne 0 || -z "$specific_version" ]]; then
-            echo -e "${RED}Failed to fetch version information${NC}"
+        if [[ -z "$release_tag" ]]; then
+            echo -e "${RED}Failed to fetch the latest release tag from GitHub${NC}"
             exit 1
         fi
     else
-        # Strip leading 'v' if present
-        requested_version="${requested_version#v}"
-        url="https://github.com/SolaceHarmony/emberharmony/releases/download/v${requested_version}/$filename"
-        specific_version=$requested_version
+        release_tag=$requested_tag
 
         # Verify the release exists before downloading
-        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/SolaceHarmony/emberharmony/releases/tag/v${requested_version}")
+        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/SolaceHarmony/emberharmony/releases/tag/${release_tag}")
         if [ "$http_status" = "404" ]; then
-            echo -e "${RED}Error: Release v${requested_version} not found${NC}"
+            echo -e "${RED}Error: Release ${release_tag} not found${NC}"
             echo -e "${MUTED}Available releases: https://github.com/SolaceHarmony/emberharmony/releases${NC}"
             exit 1
         fi
     fi
+
+    filename="$APP-$release_tag-$target$archive_ext"
+    url="https://github.com/SolaceHarmony/emberharmony/releases/download/${release_tag}/$filename"
+    specific_version=$release_tag
 fi
 
 print_message() {
@@ -229,14 +241,12 @@ check_version() {
     if command -v "$APP" >/dev/null 2>&1; then
         app_path=$(which "$APP")
 
-        ## Check the installed version
+        # Informational only: the binary reports its embedded version
+        # (version.json), which is intentionally unrelated to the release tag
+        # being installed, so equality can't be used to skip the install.
         installed_version=$("$APP" --version 2>/dev/null || echo "")
-
-        if [[ "$installed_version" != "$specific_version" ]]; then
-            print_message info "${MUTED}Installed version: ${NC}$installed_version."
-        else
-            print_message info "${MUTED}Version ${NC}$specific_version${MUTED} already installed"
-            exit 0
+        if [[ -n "$installed_version" ]]; then
+            print_message info "${MUTED}Installed version: ${NC}$installed_version"
         fi
     fi
 }
@@ -368,7 +378,7 @@ verify_checksum() {
 }
 
 download_and_install() {
-    print_message info "\n${MUTED}Installing ${NC}${APP} ${MUTED}version: ${NC}$specific_version"
+    print_message info "\n${MUTED}Installing ${NC}${APP} ${MUTED}release: ${NC}$specific_version"
     local tmp_dir
     tmp_dir=$(mktemp -d)
 

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -122,6 +122,20 @@ if (!skipClean) {
   await $`rm -rf dist`
 }
 
+// The release tag (human-created in the GitHub release UI) names the release
+// and its artifacts, and is embedded so installed binaries can compare their
+// own release identity against GitHub when checking for updates. The version
+// embedded below stays version.json and is unrelated to the tag.
+const releaseTag = process.env.EMBERHARMONY_TAG ?? ""
+if (Script.release) {
+  if (!releaseTag) {
+    throw new Error("EMBERHARMONY_TAG must be set for a release build (the GitHub release tag names the archives)")
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(releaseTag)) {
+    throw new Error(`release tag "${releaseTag}" contains characters unsafe for filenames`)
+  }
+}
+
 const binaries: Record<string, string> = {}
 if (!skipInstall) {
   await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
@@ -170,6 +184,7 @@ for (const item of targets) {
     entrypoints: ["./src/index.ts", parserWorker, workerPath],
     define: {
       EMBERHARMONY_VERSION: `'${Script.version}'`,
+      EMBERHARMONY_TAG: `'${releaseTag}'`,
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
       EMBERHARMONY_WORKER_PATH: workerPath,
       EMBERHARMONY_CHANNEL: `'${Script.channel}'`,
@@ -195,17 +210,8 @@ for (const item of targets) {
 }
 
 if (Script.release) {
-  // Archive filenames are sculpted from the human-created release tag
-  // (e.g. v2.3.0 → emberharmony-v2.3.0-linux-x64.tar.gz). The tag names the
-  // release only — the version embedded in the binaries above always comes
-  // from version.json and is unrelated to the tag.
-  const releaseTag = process.env.EMBERHARMONY_TAG
-  if (!releaseTag) {
-    throw new Error("EMBERHARMONY_TAG must be set for a release build (the GitHub release tag names the archives)")
-  }
-  if (!/^[A-Za-z0-9._-]+$/.test(releaseTag)) {
-    throw new Error(`release tag "${releaseTag}" contains characters unsafe for filenames`)
-  }
+  // Archive filenames are sculpted from the release tag validated above
+  // (e.g. v2.3.0 → emberharmony-v2.3.0-linux-x64.tar.gz).
   // Optional: bundle the human-written release notes into each archive.
   const releaseNotes = process.env.EMBERHARMONY_RELEASE_NOTES
   for (const key of Object.keys(binaries)) {

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -195,8 +195,24 @@ for (const item of targets) {
 }
 
 if (Script.release) {
+  // Archive filenames are sculpted from the human-created release tag
+  // (e.g. v2.3.0 → emberharmony-v2.3.0-linux-x64.tar.gz). The tag names the
+  // release only — the version embedded in the binaries above always comes
+  // from version.json and is unrelated to the tag.
+  const releaseTag = process.env.EMBERHARMONY_TAG
+  if (!releaseTag) {
+    throw new Error("EMBERHARMONY_TAG must be set for a release build (the GitHub release tag names the archives)")
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(releaseTag)) {
+    throw new Error(`release tag "${releaseTag}" contains characters unsafe for filenames`)
+  }
+  // Optional: bundle the human-written release notes into each archive.
+  const releaseNotes = process.env.EMBERHARMONY_RELEASE_NOTES
   for (const key of Object.keys(binaries)) {
-    const releaseName = key.replace(pkg.name, cliName)
+    if (releaseNotes) {
+      await Bun.write(`dist/${key}/bin/RELEASE_NOTES.md`, releaseNotes)
+    }
+    const releaseName = key.replace(pkg.name, `${cliName}-${releaseTag}`)
     if (key.includes("linux")) {
       await $`tar -czf ../../${releaseName}.tar.gz *`.cwd(`dist/${key}/bin`)
       const hash = (await $`sha256sum ./dist/${releaseName}.tar.gz`.text()).split(/\s+/)[0]
@@ -209,7 +225,8 @@ if (Script.release) {
   }
   // The archives above are produced for distribution but are NOT uploaded from
   // here: this build is not permitted to mutate GitHub. CI exposes them as
-  // workflow artifacts; attaching them to a release is a human step.
+  // workflow artifacts; attaching them to a release is a human step
+  // (the attach-assets job in publish.yml, authorized by a scoped PAT).
 }
 
 export { binaries }

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -207,12 +207,9 @@ if (Script.release) {
       await Bun.write(`./dist/${releaseName}.zip.sha256`, hash + "\n")
     }
   }
-  // Upload the CLI archives as a separate set of assets on the release the user cut.
-  // EMBERHARMONY_TAG is the actual release tag (stable v1.3.0 or a pre-release like
-  // v1.3.0-dev.1); fall back to the static version for local/manual runs. Bun's $
-  // escapes the interpolated tag as a single argument, so it is injection-safe.
-  const releaseTag = process.env.EMBERHARMONY_TAG || `v${Script.version}`
-  await $`gh release upload ${releaseTag} ./dist/*.zip ./dist/*.tar.gz ./dist/*.sha256 --clobber`
+  // The archives above are produced for distribution but are NOT uploaded from
+  // here: this build is not permitted to mutate GitHub. CI exposes them as
+  // workflow artifacts; attaching them to a release is a human step.
 }
 
 export { binaries }

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -219,15 +219,14 @@ if (Script.release) {
       await Bun.write(`dist/${key}/bin/RELEASE_NOTES.md`, releaseNotes)
     }
     const releaseName = key.replace(pkg.name, `${cliName}-${releaseTag}`)
+    const archive = key.includes("linux") ? `${releaseName}.tar.gz` : `${releaseName}.zip`
     if (key.includes("linux")) {
-      await $`tar -czf ../../${releaseName}.tar.gz *`.cwd(`dist/${key}/bin`)
-      const hash = (await $`sha256sum ./dist/${releaseName}.tar.gz`.text()).split(/\s+/)[0]
-      await Bun.write(`./dist/${releaseName}.tar.gz.sha256`, hash + "\n")
+      await $`tar -czf ../../${archive} *`.cwd(`dist/${key}/bin`)
     } else {
-      await $`zip -r ../../${releaseName}.zip *`.cwd(`dist/${key}/bin`)
-      const hash = (await $`sha256sum ./dist/${releaseName}.zip`.text()).split(/\s+/)[0]
-      await Bun.write(`./dist/${releaseName}.zip.sha256`, hash + "\n")
+      await $`zip -r ../../${archive} *`.cwd(`dist/${key}/bin`)
     }
+    const hash = new Bun.CryptoHasher("sha256").update(await Bun.file(`./dist/${archive}`).arrayBuffer()).digest("hex")
+    await Bun.write(`./dist/${archive}.sha256`, hash + "\n")
   }
   // The archives above are produced for distribution but are NOT uploaded from
   // here: this build is not permitted to mutate GitHub. CI exposes them as

--- a/packages/emberharmony/src/cli/cmd/upgrade.ts
+++ b/packages/emberharmony/src/cli/cmd/upgrade.ts
@@ -16,7 +16,7 @@ export const UpgradeCommand = {
         alias: "m",
         describe: "installation method to use",
         type: "string",
-        choices: ["curl", "npm", "pnpm", "bun"],
+        choices: ["curl", "npm", "pnpm", "bun", "yarn"],
       })
   },
   handler: async (args: { target?: string; method?: string }) => {
@@ -45,12 +45,19 @@ export const UpgradeCommand = {
     // npm targets are bare package versions; curl targets are release tags
     // used verbatim (the tag is the release identity, unrelated to the
     // embedded version).
-    const isNpmLike = method === "npm" || method === "pnpm" || method === "bun"
-    const target = args.target
-      ? isNpmLike
-        ? args.target.replace(/^v/, "")
-        : args.target
-      : await Installation.latest(method)
+    const isNpmLike = method === "npm" || method === "pnpm" || method === "bun" || method === "yarn"
+    let target: string
+    try {
+      target = args.target
+        ? isNpmLike
+          ? args.target.replace(/^v/, "")
+          : args.target
+        : await Installation.latest(method)
+    } catch (err) {
+      prompts.log.error(`Failed to resolve the latest release: ${err instanceof Error ? err.message : String(err)}`)
+      prompts.outro("Done")
+      return
+    }
     const current = Installation.installed(method)
 
     if (current === target) {

--- a/packages/emberharmony/src/cli/cmd/upgrade.ts
+++ b/packages/emberharmony/src/cli/cmd/upgrade.ts
@@ -27,19 +27,14 @@ export const UpgradeCommand = {
     const detectedMethod = await Installation.method()
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`emberharmony is installed to ${process.execPath} and may be managed by a package manager`)
-      const install = await prompts.select({
-        message: "Install anyways?",
-        options: [
-          { label: "Yes", value: true },
-          { label: "No", value: false },
-        ],
-        initialValue: false,
-      })
-      if (!install) {
-        prompts.outro("Done")
-        return
-      }
+      // Proceeding with an unknown method can only end in Installation.upgrade
+      // throwing — tell the user how to choose one instead of pretending.
+      prompts.log.error(
+        `emberharmony is installed to ${process.execPath} and may be managed by a package manager; ` +
+          `specify how to upgrade with --method (curl, npm, pnpm, bun, yarn)`,
+      )
+      prompts.outro("Done")
+      return
     }
     prompts.log.info("Using method: " + method)
     // npm targets are bare package versions; curl targets are release tags

--- a/packages/emberharmony/src/cli/cmd/upgrade.ts
+++ b/packages/emberharmony/src/cli/cmd/upgrade.ts
@@ -9,7 +9,7 @@ export const UpgradeCommand = {
   builder: (yargs: Argv) => {
     return yargs
       .positional("target", {
-        describe: "version to upgrade to, for ex '0.1.48' or 'v0.1.48'",
+        describe: "npm version (e.g. '0.1.48') or GitHub release tag (e.g. 'v2.3.0') to upgrade to",
         type: "string",
       })
       .option("method", {
@@ -42,15 +42,24 @@ export const UpgradeCommand = {
       }
     }
     prompts.log.info("Using method: " + method)
-    const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest()
+    // npm targets are bare package versions; curl targets are release tags
+    // used verbatim (the tag is the release identity, unrelated to the
+    // embedded version).
+    const isNpmLike = method === "npm" || method === "pnpm" || method === "bun"
+    const target = args.target
+      ? isNpmLike
+        ? args.target.replace(/^v/, "")
+        : args.target
+      : await Installation.latest(method)
+    const current = Installation.installed(method)
 
-    if (Installation.VERSION === target) {
+    if (current === target) {
       prompts.log.warn(`emberharmony upgrade skipped: ${target} is already installed`)
       prompts.outro("Done")
       return
     }
 
-    prompts.log.info(`From ${Installation.VERSION} → ${target}`)
+    prompts.log.info(`From ${current} → ${target}`)
     const spinner = prompts.spinner()
     spinner.start("Upgrading...")
     const err = await Installation.upgrade(method, target).catch((err) => err)

--- a/packages/emberharmony/src/cli/upgrade.ts
+++ b/packages/emberharmony/src/cli/upgrade.ts
@@ -8,7 +8,9 @@ export async function upgrade() {
   const method = await Installation.method()
   const latest = await Installation.latest(method).catch(() => {})
   if (!latest) return
-  if (Installation.VERSION === latest) return
+  // npm installs compare package versions; GitHub installs compare release
+  // tags — the embedded version is unrelated to the release tag by design.
+  if (Installation.installed(method) === latest) return
 
   if (config.autoupdate === false || Flag.EMBERHARMONY_DISABLE_AUTOUPDATE) {
     return

--- a/packages/emberharmony/src/installation/index.ts
+++ b/packages/emberharmony/src/installation/index.ts
@@ -10,6 +10,7 @@ import { Flag } from "../flag/flag"
 declare global {
   const EMBERHARMONY_VERSION: string
   const EMBERHARMONY_CHANNEL: string
+  const EMBERHARMONY_TAG: string
 }
 
 export namespace Installation {
@@ -114,9 +115,11 @@ export namespace Installation {
     let cmd
     switch (method) {
       case "curl":
+        // The installer takes the release TAG verbatim — tags name releases;
+        // versions live in version.json and never identify a release.
         cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/dev/install | bash`.env({
           ...process.env,
-          VERSION: target,
+          TAG: target,
         })
         break
       case "npm":
@@ -148,7 +151,21 @@ export namespace Installation {
 
   export const VERSION = typeof EMBERHARMONY_VERSION === "string" ? EMBERHARMONY_VERSION : "local"
   export const CHANNEL = typeof EMBERHARMONY_CHANNEL === "string" ? EMBERHARMONY_CHANNEL : "local"
+  // The GitHub release tag this binary was built for ("" for npm/local builds).
+  // GitHub-released binaries are identified by their tag, not VERSION: the tag
+  // is human-chosen and intentionally unrelated to version.json.
+  export const TAG = typeof EMBERHARMONY_TAG === "string" ? EMBERHARMONY_TAG : ""
   export const USER_AGENT = `emberharmony/${CHANNEL}/${VERSION}/${Flag.EMBERHARMONY_CLIENT}`
+
+  // What this install reports as its current release identity, for comparison
+  // against latest(): npm-managed installs are versioned by the npm package
+  // version; GitHub (curl) installs by the release tag embedded at build time.
+  export function installed(installMethod: Method) {
+    if (installMethod === "npm" || installMethod === "pnpm" || installMethod === "bun" || installMethod === "yarn") {
+      return VERSION
+    }
+    return TAG || VERSION
+  }
 
   export async function latest(installMethod?: Method) {
     const detectedMethod = installMethod || (await method())
@@ -169,11 +186,27 @@ export namespace Installation {
         .then((data: any) => data.version)
     }
 
+    // GitHub-released binaries follow release tags verbatim. Dev-channel
+    // builds never appear in /releases/latest (dev-target releases are always
+    // prereleases), so they follow the newest prerelease targeting dev.
+    if (CHANNEL === "dev") {
+      return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=30")
+        .then((res) => {
+          if (!res.ok) throw new Error(res.statusText)
+          return res.json()
+        })
+        .then((data: any[]) => {
+          const release = data.find((item) => item.prerelease && !item.draft && item.target_commitish === "dev")
+          if (!release) throw new Error("no dev-target prerelease found on GitHub")
+          return release.tag_name as string
+        })
+    }
+
     return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest")
       .then((res) => {
         if (!res.ok) throw new Error(res.statusText)
         return res.json()
       })
-      .then((data: any) => data.tag_name.replace(/^v/, ""))
+      .then((data: any) => data.tag_name as string)
   }
 }

--- a/packages/emberharmony/src/installation/index.ts
+++ b/packages/emberharmony/src/installation/index.ts
@@ -1,4 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
+import os from "os"
 import path from "path"
 import { $ } from "bun"
 import z from "zod"
@@ -114,16 +115,34 @@ export namespace Installation {
   export async function upgrade(method: Method, target: string) {
     let cmd
     switch (method) {
-      case "curl":
+      case "curl": {
+        // The tag is interpolated into a URL whose response gets executed,
+        // and URL clients normalize ../ segments — a crafted tag could
+        // otherwise address an arbitrary repository. Enforce the same
+        // release-tag character allowlist as build.ts and the install script.
+        if (!/^[A-Za-z0-9._-]+$/.test(target)) {
+          throw new Error(`invalid release tag "${target}"`)
+        }
         // The installer takes the release TAG verbatim — tags name releases;
         // versions live in version.json and never identify a release. The
-        // installer script itself is fetched at the target tag's ref so the
-        // install is reproducible and matches the release being installed.
-        cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/${target}/install | bash`.env({
+        // installer script is fetched at the target tag's ref so the install
+        // is reproducible, and fetched explicitly rather than `curl | bash`:
+        // in a pipe, bash exits 0 on empty input when curl fails, silently
+        // no-op'ing the upgrade while reporting success.
+        const res = await fetch(`https://raw.githubusercontent.com/SolaceHarmony/emberharmony/${target}/install`, {
+          headers: { "User-Agent": USER_AGENT },
+        })
+        if (!res.ok) {
+          throw new Error(`failed to fetch installer for ${target}: ${res.status} ${res.statusText}`)
+        }
+        const installer = path.join(os.tmpdir(), `emberharmony-install-${target}.sh`)
+        await Bun.write(installer, await res.text())
+        cmd = $`bash ${installer}`.env({
           ...process.env,
           TAG: target,
         })
         break
+      }
       case "npm":
         cmd = $`npm install -g ${npmName}@${target}`
         break

--- a/packages/emberharmony/src/installation/index.ts
+++ b/packages/emberharmony/src/installation/index.ts
@@ -116,8 +116,10 @@ export namespace Installation {
     switch (method) {
       case "curl":
         // The installer takes the release TAG verbatim — tags name releases;
-        // versions live in version.json and never identify a release.
-        cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/dev/install | bash`.env({
+        // versions live in version.json and never identify a release. The
+        // installer script itself is fetched at the target tag's ref so the
+        // install is reproducible and matches the release being installed.
+        cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/${target}/install | bash`.env({
           ...process.env,
           TAG: target,
         })
@@ -130,6 +132,9 @@ export namespace Installation {
         break
       case "bun":
         cmd = $`bun install -g ${npmName}@${target}`
+        break
+      case "yarn":
+        cmd = $`yarn global add ${npmName}@${target}`
         break
       default:
         throw new Error(`Unknown method: ${method}`)
@@ -170,7 +175,7 @@ export namespace Installation {
   export async function latest(installMethod?: Method) {
     const detectedMethod = installMethod || (await method())
 
-    if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {
+    if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm" || detectedMethod === "yarn") {
       const registry = await iife(async () => {
         const r = (await $`npm config get registry`.quiet().nothrow().text()).trim()
         const reg = r || "https://registry.npmjs.org"
@@ -190,7 +195,9 @@ export namespace Installation {
     // builds never appear in /releases/latest (dev-target releases are always
     // prereleases), so they follow the newest prerelease targeting dev.
     if (CHANNEL === "dev") {
-      return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=30")
+      return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=30", {
+        headers: { "User-Agent": USER_AGENT },
+      })
         .then((res) => {
           if (!res.ok) throw new Error(res.statusText)
           return res.json()
@@ -202,7 +209,9 @@ export namespace Installation {
         })
     }
 
-    return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest")
+    return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest", {
+      headers: { "User-Agent": USER_AGENT },
+    })
       .then((res) => {
         if (!res.ok) throw new Error(res.statusText)
         return res.json()

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -18,14 +18,23 @@ if (!semver.satisfies(process.versions.bun, expectedBunVersionRange)) {
 const env = {
   EMBERHARMONY_CHANNEL: process.env["EMBERHARMONY_CHANNEL"],
   EMBERHARMONY_RELEASE: process.env["EMBERHARMONY_RELEASE"],
+  EMBERHARMONY_TARGET: process.env["EMBERHARMONY_TARGET"],
 }
 
 const CHANNEL = await (async () => {
   if (env.EMBERHARMONY_CHANNEL) return env.EMBERHARMONY_CHANNEL
-  // A release build (EMBERHARMONY_RELEASE set) is always the stable channel. Releases
-  // run on a detached tag checkout where `git branch` can't see dev/main, so we key off
-  // the release context instead of the branch. Local/CI branch builds keep preview logic.
-  if (env.EMBERHARMONY_RELEASE) return "latest"
+  // Release builds run on a detached tag checkout where `git branch` can't see
+  // dev/main, so the channel comes from the branch the human targeted in the
+  // GitHub release UI (EMBERHARMONY_TARGET = release.target_commitish):
+  // main → stable "latest", dev → "dev". Anything else is a misconfigured
+  // release and fails the build. Local/CI branch builds keep preview logic.
+  if (env.EMBERHARMONY_RELEASE) {
+    if (env.EMBERHARMONY_TARGET === "main") return "latest"
+    if (env.EMBERHARMONY_TARGET === "dev") return "dev"
+    throw new Error(
+      `release builds require EMBERHARMONY_TARGET of "main" or "dev", got "${env.EMBERHARMONY_TARGET ?? "(unset)"}"`,
+    )
+  }
   const branch = await $`git branch --show-current`
     .text()
     .then((x) => x.trim())
@@ -45,9 +54,14 @@ const STATIC_VERSION = await (async () => {
   return data.version
 })()
 
-const VERSION = IS_PREVIEW
-  ? `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
-  : STATIC_VERSION
+// The embedded version is hard-coded from version.json for every release
+// build regardless of tag or channel — the tag names the release, it never
+// defines the version. Timestamped preview versions exist only for local /
+// non-integration-branch builds.
+const VERSION =
+  env.EMBERHARMONY_RELEASE || !IS_PREVIEW
+    ? STATIC_VERSION
+    : `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
 
 export const Script = {
   get channel() {

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -35,11 +35,15 @@ const CHANNEL = await (async () => {
       `release builds require EMBERHARMONY_TARGET of "main" or "dev", got "${env.EMBERHARMONY_TARGET ?? "(unset)"}"`,
     )
   }
+  // Branch builds mirror the release mapping: main → "latest", dev → "dev".
+  // A dev-branch build is therefore IS_PREVIEW and gets a timestamped version,
+  // so CI verification artifacts can never impersonate a pinned release build
+  // (release builds bypass this via EMBERHARMONY_RELEASE above).
   const branch = await $`git branch --show-current`
     .text()
     .then((x) => x.trim())
     .catch(() => "")
-  return branch === "dev" || branch === "main" ? "latest" : branch || "preview"
+  return branch === "main" ? "latest" : branch || "preview"
 })()
 const IS_PREVIEW = CHANNEL !== "latest"
 


### PR DESCRIPTION
## Summary

Brings `dev` into `main`: PRs #66 and #67 — the release-pipeline redesign enforcing enterprise no-writes policy and the tag/version separation.

## Key changes

- **CI cannot mutate the repo** — default `GITHUB_TOKEN` is read-only in every workflow; `build.ts` has no release/upload capability; the single sanctioned write (attaching archives to a human-created release) is a dedicated `attach-assets` job using the scoped `RELEASE_ASSETS_TOKEN` PAT (#66).
- **Upstream PR template removed** (#66).
- **Tag names the release; version.json names the build** — archive filenames sculpted from the human-created tag; embedded version always from `version.json` (#67).
- **Channel from release target** — `main` → `latest`, `dev` → `dev`, anything else fails the build. Branch builds mirror the mapping; dev CI builds are timestamped previews (#67).
- **npm gated to stable main-target releases**; dev releases ship binaries to the release page only (#67).
- **Updater & installer follow tags** — release binaries embed their tag; GitHub-method update checks compare tag-to-tag; dev binaries follow the newest dev-target prerelease; installer addresses releases by `--tag`/`TAG` (legacy `VERSION` fails loudly) (#67).
- **Guardrail:** a dev-target release not marked pre-release refuses to build, so it can never become `/releases/latest` (#67).

## After merge

1. Add the `RELEASE_ASSETS_TOKEN` secret (fine-grained PAT, this repo, Contents read/write).
2. Cut a dev-target pre-release (e.g. `v1.3.0-dev.2`) to verify the full pipeline end-to-end: tag-named assets attached, npm untouched, installer resolves the new names.