### PR TITLE
Address PR #68 review: API user-agent, yarn support, portable hashing, tag validation order

### DIFF
--- a/install
+++ b/install
@@ -195,6 +195,16 @@ else
         fi
     fi
 
+    # The tag becomes part of filenames and URLs — refuse anything that could
+    # traverse paths or smuggle shell/URL syntax (same rule as build.ts).
+    # Must run BEFORE the tag is interpolated into any URL or path.
+    validate_tag() {
+        if [[ ! "$1" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo -e "${RED}Error: Release tag '$1' contains unsafe characters${NC}"
+            exit 1
+        fi
+    }
+
     # Resolve the release tag, then sculpt the asset filename from it
     # (e.g. v2.3.0 -> emberharmony-v2.3.0-linux-x64.tar.gz). Tags are used
     # verbatim — releases older than the tag-named scheme cannot be installed
@@ -206,8 +216,10 @@ else
             echo -e "${RED}Failed to fetch the latest release tag from GitHub${NC}"
             exit 1
         fi
+        validate_tag "$release_tag"
     else
         release_tag=$requested_tag
+        validate_tag "$release_tag"
 
         # Verify the release exists before downloading
         http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/SolaceHarmony/emberharmony/releases/tag/${release_tag}")

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -219,15 +219,14 @@ if (Script.release) {
       await Bun.write(`dist/${key}/bin/RELEASE_NOTES.md`, releaseNotes)
     }
     const releaseName = key.replace(pkg.name, `${cliName}-${releaseTag}`)
+    const archive = key.includes("linux") ? `${releaseName}.tar.gz` : `${releaseName}.zip`
     if (key.includes("linux")) {
-      await $`tar -czf ../../${releaseName}.tar.gz *`.cwd(`dist/${key}/bin`)
-      const hash = (await $`sha256sum ./dist/${releaseName}.tar.gz`.text()).split(/\s+/)[0]
-      await Bun.write(`./dist/${releaseName}.tar.gz.sha256`, hash + "\n")
+      await $`tar -czf ../../${archive} *`.cwd(`dist/${key}/bin`)
     } else {
-      await $`zip -r ../../${releaseName}.zip *`.cwd(`dist/${key}/bin`)
-      const hash = (await $`sha256sum ./dist/${releaseName}.zip`.text()).split(/\s+/)[0]
-      await Bun.write(`./dist/${releaseName}.zip.sha256`, hash + "\n")
+      await $`zip -r ../../${archive} *`.cwd(`dist/${key}/bin`)
     }
+    const hash = new Bun.CryptoHasher("sha256").update(await Bun.file(`./dist/${archive}`).arrayBuffer()).digest("hex")
+    await Bun.write(`./dist/${archive}.sha256`, hash + "\n")
   }
   // The archives above are produced for distribution but are NOT uploaded from
   // here: this build is not permitted to mutate GitHub. CI exposes them as

--- a/packages/emberharmony/src/cli/cmd/upgrade.ts
+++ b/packages/emberharmony/src/cli/cmd/upgrade.ts
@@ -16,7 +16,7 @@ export const UpgradeCommand = {
         alias: "m",
         describe: "installation method to use",
         type: "string",
-        choices: ["curl", "npm", "pnpm", "bun"],
+        choices: ["curl", "npm", "pnpm", "bun", "yarn"],
       })
   },
   handler: async (args: { target?: string; method?: string }) => {
@@ -45,12 +45,19 @@ export const UpgradeCommand = {
     // npm targets are bare package versions; curl targets are release tags
     // used verbatim (the tag is the release identity, unrelated to the
     // embedded version).
-    const isNpmLike = method === "npm" || method === "pnpm" || method === "bun"
-    const target = args.target
-      ? isNpmLike
-        ? args.target.replace(/^v/, "")
-        : args.target
-      : await Installation.latest(method)
+    const isNpmLike = method === "npm" || method === "pnpm" || method === "bun" || method === "yarn"
+    let target: string
+    try {
+      target = args.target
+        ? isNpmLike
+          ? args.target.replace(/^v/, "")
+          : args.target
+        : await Installation.latest(method)
+    } catch (err) {
+      prompts.log.error(`Failed to resolve the latest release: ${err instanceof Error ? err.message : String(err)}`)
+      prompts.outro("Done")
+      return
+    }
     const current = Installation.installed(method)
 
     if (current === target) {

--- a/packages/emberharmony/src/cli/cmd/upgrade.ts
+++ b/packages/emberharmony/src/cli/cmd/upgrade.ts
@@ -27,19 +27,14 @@ export const UpgradeCommand = {
     const detectedMethod = await Installation.method()
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`emberharmony is installed to ${process.execPath} and may be managed by a package manager`)
-      const install = await prompts.select({
-        message: "Install anyways?",
-        options: [
-          { label: "Yes", value: true },
-          { label: "No", value: false },
-        ],
-        initialValue: false,
-      })
-      if (!install) {
-        prompts.outro("Done")
-        return
-      }
+      // Proceeding with an unknown method can only end in Installation.upgrade
+      // throwing — tell the user how to choose one instead of pretending.
+      prompts.log.error(
+        `emberharmony is installed to ${process.execPath} and may be managed by a package manager; ` +
+          `specify how to upgrade with --method (curl, npm, pnpm, bun, yarn)`,
+      )
+      prompts.outro("Done")
+      return
     }
     prompts.log.info("Using method: " + method)
     // npm targets are bare package versions; curl targets are release tags

--- a/packages/emberharmony/src/installation/index.ts
+++ b/packages/emberharmony/src/installation/index.ts
@@ -1,4 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
+import os from "os"
 import path from "path"
 import { $ } from "bun"
 import z from "zod"
@@ -114,16 +115,34 @@ export namespace Installation {
   export async function upgrade(method: Method, target: string) {
     let cmd
     switch (method) {
-      case "curl":
+      case "curl": {
+        // The tag is interpolated into a URL whose response gets executed,
+        // and URL clients normalize ../ segments — a crafted tag could
+        // otherwise address an arbitrary repository. Enforce the same
+        // release-tag character allowlist as build.ts and the install script.
+        if (!/^[A-Za-z0-9._-]+$/.test(target)) {
+          throw new Error(`invalid release tag "${target}"`)
+        }
         // The installer takes the release TAG verbatim — tags name releases;
         // versions live in version.json and never identify a release. The
-        // installer script itself is fetched at the target tag's ref so the
-        // install is reproducible and matches the release being installed.
-        cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/${target}/install | bash`.env({
+        // installer script is fetched at the target tag's ref so the install
+        // is reproducible, and fetched explicitly rather than `curl | bash`:
+        // in a pipe, bash exits 0 on empty input when curl fails, silently
+        // no-op'ing the upgrade while reporting success.
+        const res = await fetch(`https://raw.githubusercontent.com/SolaceHarmony/emberharmony/${target}/install`, {
+          headers: { "User-Agent": USER_AGENT },
+        })
+        if (!res.ok) {
+          throw new Error(`failed to fetch installer for ${target}: ${res.status} ${res.statusText}`)
+        }
+        const installer = path.join(os.tmpdir(), `emberharmony-install-${target}.sh`)
+        await Bun.write(installer, await res.text())
+        cmd = $`bash ${installer}`.env({
           ...process.env,
           TAG: target,
         })
         break
+      }
       case "npm":
         cmd = $`npm install -g ${npmName}@${target}`
         break

--- a/packages/emberharmony/src/installation/index.ts
+++ b/packages/emberharmony/src/installation/index.ts
@@ -116,8 +116,10 @@ export namespace Installation {
     switch (method) {
       case "curl":
         // The installer takes the release TAG verbatim — tags name releases;
-        // versions live in version.json and never identify a release.
-        cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/dev/install | bash`.env({
+        // versions live in version.json and never identify a release. The
+        // installer script itself is fetched at the target tag's ref so the
+        // install is reproducible and matches the release being installed.
+        cmd = $`curl -fsSL https://raw.githubusercontent.com/SolaceHarmony/emberharmony/${target}/install | bash`.env({
           ...process.env,
           TAG: target,
         })
@@ -130,6 +132,9 @@ export namespace Installation {
         break
       case "bun":
         cmd = $`bun install -g ${npmName}@${target}`
+        break
+      case "yarn":
+        cmd = $`yarn global add ${npmName}@${target}`
         break
       default:
         throw new Error(`Unknown method: ${method}`)
@@ -170,7 +175,7 @@ export namespace Installation {
   export async function latest(installMethod?: Method) {
     const detectedMethod = installMethod || (await method())
 
-    if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {
+    if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm" || detectedMethod === "yarn") {
       const registry = await iife(async () => {
         const r = (await $`npm config get registry`.quiet().nothrow().text()).trim()
         const reg = r || "https://registry.npmjs.org"
@@ -190,7 +195,9 @@ export namespace Installation {
     // builds never appear in /releases/latest (dev-target releases are always
     // prereleases), so they follow the newest prerelease targeting dev.
     if (CHANNEL === "dev") {
-      return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=30")
+      return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=30", {
+        headers: { "User-Agent": USER_AGENT },
+      })
         .then((res) => {
           if (!res.ok) throw new Error(res.statusText)
           return res.json()
@@ -202,7 +209,9 @@ export namespace Installation {
         })
     }
 
-    return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest")
+    return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest", {
+      headers: { "User-Agent": USER_AGENT },
+    })
       .then((res) => {
         if (!res.ok) throw new Error(res.statusText)
         return res.json()


### PR DESCRIPTION
## Summary

Fixes for the review findings on #68 (dev→main). Once this merges to `dev`, #68 picks the changes up automatically.

## Changes

- **GitHub API user-agent** — both `Installation.latest()` fetches now send the app `USER_AGENT`.
- **Full yarn support** — yarn was detected by `method()` but missing from `latest()` (fell through to the GitHub path) and `upgrade()` (threw "Unknown method"). Now: npm-registry lookup, `yarn global add` upgrade, included in the upgrade command's normalization and `--method` choices.
- **Reproducible installer fetch** — curl upgrades fetch the installer at the target tag's ref rather than the `dev` branch head.
- **Portable hashing** — archive checksums via `Bun.CryptoHasher` instead of spawning `sha256sum` (absent on macOS/Windows). Verified to produce identical digests.
- **Tag validation order** — the installer validates the tag against the build.ts character allowlist in *both* resolution paths, before the tag reaches any URL or path. Previously a malicious `--tag` was interpolated into the existence-check URL before validation.

## Test plan

- [x] 12/12 typecheck; `bash -n`
- [x] Live API: stable + dev `latest()` resolve correctly with the UA header
- [x] `CryptoHasher` digest matches `shasum -a 256`
- [x] Installer rejects `../evil` and `v1.0;rm -rf` before any URL use; valid-but-missing tag still 404s cleanly