### PR TITLE
Channel from the pre-release flag with main-ancestry enforcement; gate npm on assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,24 +19,44 @@ permissions:
   actions: read
 
 jobs:
-  # A release targeting dev that is not marked as a pre-release would become
-  # GitHub's /releases/latest — the target of every stable curl install and
-  # update check — so a single missed checkbox would ship dev binaries to
-  # stable users. Refuse to build it.
+  # The human-controlled pre-release checkbox IS the channel selector:
+  # pre-release → dev channel, stable → main channel. It cannot be derived
+  # from release.target_commitish (GitHub documents that field as unused when
+  # a release is cut from an existing tag — it then reports the default
+  # branch) nor from tag-commit ancestry alone (after a dev→main merge, dev
+  # commits are reachable from main too). The ancestry check below is the
+  # safety net for the checkbox: a stable release whose tag is not on main —
+  # e.g. someone cut a stable release from the dev tip — refuses to build,
+  # because it would become GitHub's /releases/latest, the target of every
+  # stable curl install and update check.
   validate:
     runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.channel.outputs.channel }}
     steps:
-      - name: Require dev-target releases to be pre-releases
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Derive channel from the pre-release flag; stable must come from main
+        id: channel
         env:
-          TARGET: ${{ github.event.release.target_commitish }}
+          TAG: ${{ github.event.release.tag_name }}
           PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           set -euo pipefail
-          if [ "$TARGET" = "dev" ] && [ "$PRERELEASE" != "true" ]; then
-            echo "::error::Release targets dev but is not marked as a pre-release. Delete the release, recreate it with the pre-release checkbox set, and try again."
-            exit 1
+          commit=$(git rev-list -n1 "refs/tags/$TAG")
+          if [ "$PRERELEASE" = "true" ]; then
+            channel=dev
+          else
+            channel=main
+            if ! git merge-base --is-ancestor "$commit" origin/main; then
+              echo "::error::Stable release $TAG ($commit) is not reachable from main. Stable releases must be cut from main; for a dev build, recreate the release with the pre-release checkbox set."
+              exit 1
+            fi
           fi
-          echo "release target=$TARGET prerelease=$PRERELEASE — ok"
+          echo "tag=$TAG commit=$commit channel=$channel prerelease=$PRERELEASE — ok"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
 
   build:
     needs:
@@ -45,10 +65,10 @@ jobs:
     with:
       release: ${{ github.event.release.id }}
       tag: ${{ github.event.release.tag_name }}
-      # The branch the human picked as the release target in the GitHub UI.
-      # main → stable ("latest"), dev → dev channel; the build fails on
-      # anything else.
-      target: ${{ github.event.release.target_commitish }}
+      # The branch the tag's commit actually belongs to, resolved by the
+      # validate job (release.target_commitish is unreliable for releases cut
+      # from existing tags). main → stable ("latest"), dev → dev channel.
+      target: ${{ needs.validate.outputs.channel }}
       release-notes: ${{ github.event.release.body }}
       publish-name: "@thesolaceproject/emberharmony"
     secrets: inherit
@@ -80,13 +100,16 @@ jobs:
           gh release upload "$TAG" dist/*.tar.gz dist/*.zip dist/*.sha256 \
             --clobber --repo "${{ github.repository }}"
 
-  # npm publish runs ONLY for stable releases targeting main. A dev-target or
-  # pre-release build still ships binaries to the release page via
-  # attach-assets, but never touches npm.
+  # npm publish runs ONLY for stable main-channel releases, and only after the
+  # GitHub release assets are attached — an npm package must never point at a
+  # release whose binaries failed to upload. A dev or pre-release build still
+  # ships binaries to the release page via attach-assets, but never touches npm.
   publish:
-    if: ${{ github.repository == 'SolaceHarmony/emberharmony' && !github.event.release.prerelease && github.event.release.target_commitish == 'main' }}
+    if: ${{ github.repository == 'SolaceHarmony/emberharmony' && !github.event.release.prerelease && needs.validate.outputs.channel == 'main' }}
     needs:
+      - validate
       - build
+      - attach-assets
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -122,7 +145,7 @@ jobs:
       - run: ./script/publish.ts
         env:
           EMBERHARMONY_RELEASE: ${{ github.event.release.id }}
-          EMBERHARMONY_TARGET: ${{ github.event.release.target_commitish }}
+          EMBERHARMONY_TARGET: ${{ needs.validate.outputs.channel }}
           EMBERHARMONY_PUBLISH_NAME: "@thesolaceproject/emberharmony"
           EMBERHARMONY_PUBLISH_PLATFORMS: "1"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/emberharmony/src/installation/index.ts
+++ b/packages/emberharmony/src/installation/index.ts
@@ -211,21 +211,25 @@ export namespace Installation {
     }
 
     // GitHub-released binaries follow release tags verbatim. Dev-channel
-    // builds never appear in /releases/latest (dev-target releases are always
-    // prereleases), so they follow the newest prerelease targeting dev.
+    // builds never appear in /releases/latest (dev releases are always
+    // prereleases — enforced by the publish workflow's validate gate, which
+    // is also why prerelease status alone identifies the dev stream here:
+    // release.target_commitish is unreliable for releases cut from existing
+    // tags). Paginate: the newest dev prerelease may sit behind many stable
+    // releases in the listing.
     if (CHANNEL === "dev") {
-      return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=30", {
-        headers: { "User-Agent": USER_AGENT },
-      })
-        .then((res) => {
-          if (!res.ok) throw new Error(res.statusText)
-          return res.json()
-        })
-        .then((data: any[]) => {
-          const release = data.find((item) => item.prerelease && !item.draft && item.target_commitish === "dev")
-          if (!release) throw new Error("no dev-target prerelease found on GitHub")
-          return release.tag_name as string
-        })
+      for (let page = 1; page <= 10; page++) {
+        const res = await fetch(
+          `https://api.github.com/repos/SolaceHarmony/emberharmony/releases?per_page=100&page=${page}`,
+          { headers: { "User-Agent": USER_AGENT } },
+        )
+        if (!res.ok) throw new Error(res.statusText)
+        const data = (await res.json()) as any[]
+        const release = data.find((item) => item.prerelease && !item.draft)
+        if (release) return release.tag_name as string
+        if (data.length < 100) break
+      }
+      throw new Error("no dev prerelease found on GitHub")
     }
 
     return fetch("https://api.github.com/repos/SolaceHarmony/emberharmony/releases/latest", {


### PR DESCRIPTION
## Summary

Addresses the second round of review findings on #68 (the Codex comments). Once merged to `dev`, #68 inherits the changes.

## Changes

- **Channel selection no longer trusts `target_commitish`** — GitHub documents that field as unused when a release is cut from an existing tag (it then reports the default branch, `dev` here), which could mislabel a stable release. The pre-release checkbox now selects the channel (pre-release → `dev`, stable → `main`), with an ancestry safety net: a stable release whose tag isn't reachable from `main` refuses to build. Pure ancestry couldn't be the selector — after a dev→main merge, dev commits are reachable from main too (verified against the real `v1.3.0-dev.1` tag, which ancestry misclassifies as main).
- **npm gated on attached assets** — `publish` now needs `attach-assets`, so a failed binary upload (e.g. missing/expired `RELEASE_ASSETS_TOKEN`) blocks the npm release instead of publishing a package pointing at 404ing binaries.
- **Dev release lookup paginates** — 100 per page, up to 10 pages, instead of only the first 30 releases; identifies the dev stream by prerelease status alone, consistent with the gate and independent of `target_commitish`.

## Test plan

- [x] 12/12 typecheck; workflow YAML validated
- [x] Gate truth table verified: stable+on-main → main+npm; prerelease → dev (any ancestry); stable+off-main → blocked
- [x] Live API: paginated dev lookup resolves `v1.3.0-dev.1`