### PR TITLE
Disable build/typecheck caching: every verification runs from scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ target
 emberharmony-dev
 logs/
 *.bun-build
+*.tsbuildinfo

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,7 +8,7 @@
     "./vite": "./vite.js"
   },
   "scripts": {
-    "typecheck": "tsgo -b",
+    "typecheck": "tsgo -b --force",
     "start": "vite",
     "dev": "vite",
     "build": "vite build",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "typecheck": "tsgo -b",
+    "typecheck": "tsgo -b --force",
     "predev": "bun ./scripts/predev.ts",
     "dev": "vite",
     "build": "bun run typecheck && vite build",

--- a/turbo.json
+++ b/turbo.json
@@ -1,18 +1,34 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
-    "typecheck": {},
+    "typecheck": {
+      "dependsOn": [
+        "^typecheck"
+      ],
+      "cache": false
+    },
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**"
+      ],
+      "cache": false
     },
     "emberharmony#test": {
-      "dependsOn": ["^build"],
-      "outputs": []
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [],
+      "cache": false
     },
     "@thesolaceproject/emberharmony-app#test": {
-      "dependsOn": ["^build"],
-      "outputs": []
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Policy: no incremental builds or cached verification results — a cache that can replay a stale "pass" is a poisoning vector for defects and tampered artifacts. The desktop typecheck flake on `dev` demonstrated it live: turbo served cached results while a cold-cache run surfaced real type errors, and a local `tsbuildinfo` made `tsgo -b` a silent no-op.

## Changes

- **`turbo.json`** — `cache: false` on every task (typecheck, build, both test tasks — tasks with empty `outputs` still cache and skip re-runs otherwise), and `typecheck` gains `dependsOn: ["^typecheck"]` so project-reference emission is ordered instead of racing across parallel workers (the likely source of the dev flake's nondeterminism).
- **`packages/desktop` + `packages/app`** — `tsgo -b --force`: full rebuild, no incremental reuse.
- **`.gitignore`** — `*.tsbuildinfo`, so incremental state can never be committed and replayed.

Cost of honesty: the full repo typecheck runs in ~4s. The cache bought nothing worth its risk.

## Test plan

- [x] `bun typecheck` twice in a row: both runs execute 12/12 tasks (`0 cached`), all pass
- [x] Stale `tsbuildinfo` files purged from the working tree