### PR TITLE
Make the desktop local build self-contained: declared requirements, preflight, no notarization

### DIFF
--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -29,7 +29,30 @@ bun run --cwd packages/desktop tauri build
 
 ## Prerequisites
 
-Running the desktop app requires additional Tauri dependencies (Rust toolchain, platform-specific libraries). See the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for setup instructions.
+Every requirement is declared in the repo; nothing relies on ad-hoc global installs:
+
+| Requirement | Declared by | Notes |
+|---|---|---|
+| Bun | `packageManager` in the root `package.json` | The only supported package manager — npm cannot resolve this workspace's `catalog:` versions |
+| Tauri CLI | `@tauri-apps/cli` devDependency | Installed by `bun install`; build scripts invoke it via `bunx tauri` (not the cargo-installed `cargo tauri`) |
+| Rust toolchain | `src-tauri/rust-toolchain.toml` | rustup picks the pinned version up automatically; install rustup via <https://rustup.rs> |
+| Platform libraries | [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) | OS packages (e.g. webkit2gtk on Linux) |
+
+`scripts/build-local.ts` verifies all of this up front (preflight) and fails with
+install guidance before any compilation starts.
+
+### macOS signing for local builds
+
+`build-local.ts` checks that `APPLE_SIGNING_IDENTITY` (usually from the repo-root
+`.env`) resolves to a certificate actually present in the keychain, and fails
+fast listing the valid identities if not. With no identity configured, local
+builds are ad-hoc signed (`-`): runnable on this machine, not distributable,
+never notarized. Notarization is exclusively a release-pipeline concern.
+
+```bash
+# explicit ad-hoc local build
+APPLE_SIGNING_IDENTITY="-" bun run --cwd packages/desktop build:local
+```
 
 ## Platform-Specific Features
 

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -34,7 +34,7 @@ Every requirement is declared in the repo; nothing relies on ad-hoc global insta
 | Requirement | Declared by | Notes |
 |---|---|---|
 | Bun | `packageManager` in the root `package.json` | The only supported package manager — npm cannot resolve this workspace's `catalog:` versions |
-| Tauri CLI | `@tauri-apps/cli` devDependency | Installed by `bun install`; build scripts invoke it via `bunx tauri` (not the cargo-installed `cargo tauri`) |
+| Tauri CLI | `@tauri-apps/cli` devDependency | Installed by `bun install`; build scripts invoke it via `bun run tauri`, resolving strictly from `node_modules/.bin` (never `bunx`, which auto-installs from the registry, and not the cargo-installed `cargo tauri`) |
 | Rust toolchain | `src-tauri/rust-toolchain.toml` | rustup picks the pinned version up automatically; install rustup via <https://rustup.rs> |
 | Platform libraries | [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) | OS packages (e.g. webkit2gtk on Linux) |
 

--- a/packages/desktop/scripts/build-local.ts
+++ b/packages/desktop/scripts/build-local.ts
@@ -87,9 +87,11 @@ console.log(`[build-local] target: ${rustTarget} (${sidecar.ocBinary})`)
     missing.push("Rust toolchain (cargo) — install via https://rustup.rs; src-tauri/rust-toolchain.toml pins the version")
   }
 
-  // The Tauri CLI is this package's @tauri-apps/cli devDependency, resolved
-  // from node_modules/.bin by bunx — not a cargo-installed global.
-  const tauri = await $`bunx tauri --version`.quiet().nothrow()
+  // The Tauri CLI is this package's @tauri-apps/cli devDependency, run via
+  // the package's "tauri" script so it resolves strictly from
+  // node_modules/.bin — never bunx, which would auto-install the deprecated
+  // npm package named "tauri" from the registry when node_modules is absent.
+  const tauri = await $`bun run tauri --version`.quiet().nothrow()
   if (tauri.exitCode !== 0) {
     missing.push("Tauri CLI (@tauri-apps/cli devDependency) — run `bun install` at the repo root")
   }
@@ -180,12 +182,13 @@ await copyBinaryToSidecarFolder(cliBinaryPath, rustTarget)
 
 // --- Step 3: Run tauri build (no-bundle to skip the broken DMG path) ------
 // The Tauri CLI comes from this package's @tauri-apps/cli devDependency
-// (resolved from node_modules/.bin by bunx), NOT the cargo-installed
+// (run via the package's "tauri" script, strictly from node_modules/.bin),
+// NOT the cargo-installed
 // `cargo tauri` subcommand — that is a separate global install this repo
 // neither declares nor requires.
 if (noBundle) {
   console.log(`[build-local] running: tauri build --no-bundle`)
-  await $`bunx tauri build --no-bundle`
+  await $`bun run tauri build --no-bundle`
   console.log(`[build-local] done (no bundle)`)
   process.exit(0)
 }
@@ -205,7 +208,7 @@ if (process.platform === "darwin") {
 }
 
 console.log(`[build-local] running: tauri ${tauriArgs.join(" ")}`)
-await $`bunx tauri ${tauriArgs}`
+await $`bun run tauri ${tauriArgs}`
 
 // --- Step 4: Create DMG manually (macOS only) -----------------------------
 if (process.platform === "darwin" && !noDmg) {

--- a/packages/desktop/scripts/build-local.ts
+++ b/packages/desktop/scripts/build-local.ts
@@ -5,7 +5,8 @@
  * Handles the full pipeline:
  *   1. Builds the emberharmony CLI binary for the current platform
  *   2. Copies it into src-tauri/sidecars/ as the Tauri sidecar
- *   3. Runs `cargo tauri build` (no DMG, to avoid the upstream Tauri bundle_dmg.sh bug)
+ *   3. Runs `tauri build` via the @tauri-apps/cli devDependency (no DMG, to
+ *      avoid the upstream Tauri bundle_dmg.sh bug)
  *   4. Creates a DMG manually via `hdiutil` on macOS
  *
  * Flags:
@@ -76,6 +77,90 @@ const sidecar = getCurrentSidecar(rustTarget)
 
 console.log(`[build-local] target: ${rustTarget} (${sidecar.ocBinary})`)
 
+// --- Step 0: Preflight — verify every requirement before spending minutes
+// compiling. Each failure names the missing tool and how to get it.
+{
+  const missing: string[] = []
+
+  const cargo = await $`cargo --version`.quiet().nothrow()
+  if (cargo.exitCode !== 0) {
+    missing.push("Rust toolchain (cargo) — install via https://rustup.rs; src-tauri/rust-toolchain.toml pins the version")
+  }
+
+  // The Tauri CLI is this package's @tauri-apps/cli devDependency, resolved
+  // from node_modules/.bin by bunx — not a cargo-installed global.
+  const tauri = await $`bunx tauri --version`.quiet().nothrow()
+  if (tauri.exitCode !== 0) {
+    missing.push("Tauri CLI (@tauri-apps/cli devDependency) — run `bun install` at the repo root")
+  }
+
+  if (process.platform === "darwin" && !noDmg && !noBundle) {
+    const hdiutil = await $`hdiutil info`.quiet().nothrow()
+    if (hdiutil.exitCode !== 0) {
+      missing.push("hdiutil (macOS DMG creation) — or pass --no-dmg to skip the DMG step")
+    }
+  }
+
+  // Notarization is a release-pipeline concern and is impossible for a local
+  // ad-hoc build, but Tauri auto-notarizes whenever the Apple API/ID env vars
+  // are present (and the repo-root .env carries them for releases). Strip
+  // them for local builds — explicitly and loudly — unless the caller opts
+  // in with EMBERHARMONY_NOTARIZE=1.
+  if (process.platform === "darwin" && !noBundle) {
+    const notarizeVars = ["APPLE_API_KEY", "APPLE_API_ISSUER", "APPLE_API_KEY_PATH", "APPLE_ID", "APPLE_PASSWORD"]
+    if (process.env.EMBERHARMONY_NOTARIZE === "1") {
+      const keyPath = process.env.APPLE_API_KEY_PATH
+      if (keyPath && !existsSync(keyPath)) {
+        missing.push(`APPLE_API_KEY_PATH points to "${keyPath}" which does not exist on this machine`)
+      }
+    } else {
+      const present = notarizeVars.filter((name) => process.env[name])
+      if (present.length > 0) {
+        for (const name of present) delete process.env[name]
+        console.log(
+          `[build-local] notarization disabled for local builds — ignoring ${present.join(", ")} ` +
+            `(set EMBERHARMONY_NOTARIZE=1 to attempt notarization)`,
+        )
+      }
+    }
+  }
+
+  // macOS signing: verify the configured identity actually resolves BEFORE
+  // the compile, because Tauri's own failure ("failed to sign app") names
+  // neither the identity nor the reason. "-" is ad-hoc signing and needs no
+  // keychain entry — the right mode for local, non-distributed builds.
+  if (process.platform === "darwin" && !noBundle) {
+    const identity = process.env.APPLE_SIGNING_IDENTITY
+    if (identity && identity !== "-") {
+      const identities = (await $`security find-identity -v -p codesigning`.quiet().nothrow()).stdout.toString()
+      if (!identities.includes(identity)) {
+        missing.push(
+          `signing identity "${identity}" (from APPLE_SIGNING_IDENTITY / .env) is not in the keychain.\n` +
+            `    Valid identities:\n${identities
+              .split("\n")
+              .filter((line) => line.includes('"'))
+              .map((line) => `      ${line.trim()}`)
+              .join("\n")}\n` +
+            `    Install that certificate, fix .env, or run with APPLE_SIGNING_IDENTITY="-" for an ad-hoc local build`,
+        )
+      }
+    } else if (!identity) {
+      // Explicit, logged choice — not a silent fallback: local builds without
+      // a configured identity are ad-hoc signed (runnable locally, not
+      // distributable, never notarized).
+      process.env.APPLE_SIGNING_IDENTITY = "-"
+      console.log(`[build-local] no APPLE_SIGNING_IDENTITY configured — using ad-hoc signing ("-") for this local build`)
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error(`[build-local] missing requirements:`)
+    for (const item of missing) console.error(`  - ${item}`)
+    process.exit(1)
+  }
+  console.log(`[build-local] preflight ok: ${cargo.stdout.toString().trim()}, tauri-cli ${tauri.stdout.toString().trim()}`)
+}
+
 // --- Step 1: Build CLI binary ---------------------------------------------
 const cliBinaryPath = path.join(emberharmonyDir, "dist", sidecar.ocBinary, "bin", windowsify("emberharmony"))
 
@@ -94,9 +179,13 @@ console.log(`[build-local] copying sidecar to src-tauri/sidecars/...`)
 await copyBinaryToSidecarFolder(cliBinaryPath, rustTarget)
 
 // --- Step 3: Run tauri build (no-bundle to skip the broken DMG path) ------
+// The Tauri CLI comes from this package's @tauri-apps/cli devDependency
+// (resolved from node_modules/.bin by bunx), NOT the cargo-installed
+// `cargo tauri` subcommand — that is a separate global install this repo
+// neither declares nor requires.
 if (noBundle) {
-  console.log(`[build-local] running: cargo tauri build --no-bundle`)
-  await $`cargo tauri build --no-bundle`
+  console.log(`[build-local] running: tauri build --no-bundle`)
+  await $`bunx tauri build --no-bundle`
   console.log(`[build-local] done (no bundle)`)
   process.exit(0)
 }
@@ -104,7 +193,7 @@ if (noBundle) {
 // Always skip DMG in the Tauri invocation because the upstream bundle_dmg.sh
 // fails. We create the DMG manually afterwards if the host is macOS.
 const tauriArgs = ["build"]
-// Note: `cargo tauri build` is release mode by default; `--debug` is the only toggle.
+// Note: `tauri build` is release mode by default; `--debug` is the only toggle.
 
 // Build only the .app on macOS (skip dmg in Tauri's own bundler)
 if (process.platform === "darwin") {
@@ -115,8 +204,8 @@ if (process.platform === "darwin") {
   tauriArgs.push("--bundles", "nsis,msi")
 }
 
-console.log(`[build-local] running: cargo tauri ${tauriArgs.join(" ")}`)
-await $`cargo tauri ${tauriArgs}`
+console.log(`[build-local] running: tauri ${tauriArgs.join(" ")}`)
+await $`bunx tauri ${tauriArgs}`
 
 // --- Step 4: Create DMG manually (macOS only) -----------------------------
 if (process.platform === "darwin" && !noDmg) {

--- a/packages/desktop/src-tauri/rust-toolchain.toml
+++ b/packages/desktop/src-tauri/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pinned Rust toolchain for the desktop (Tauri) build. rustup reads this file
+# automatically when building inside src-tauri, so every machine builds with
+# the same compiler instead of whatever happens to be installed.
+[toolchain]
+channel = "1.93.0"


### PR DESCRIPTION
## Summary

`bun run --cwd packages/desktop build:local` failed three different ways on a fresh machine, each from undeclared global state. Every requirement is now declared in the repo and verified up front.

## What was broken

1. **`cargo tauri` not found** — the script invoked the cargo-subcommand flavor of the Tauri CLI, a global `cargo install tauri-cli` nothing declares. The repo already ships `@tauri-apps/cli` as a devDependency; the script now uses it via `bunx tauri`.
2. **`codesign: failed to sign app`** — `.env`'s `APPLE_SIGNING_IDENTITY` named a certificate not present in the keychain, and Tauri's error names neither the identity nor the reason.
3. **Notarization attempted locally** — Tauri auto-notarizes whenever the Apple API env vars exist (the repo `.env` carries them for releases), then died on an `APPLE_API_KEY_PATH` from a different machine.

## Changes

- **Preflight in `build-local.ts`**: verifies cargo, the Tauri CLI, `hdiutil`, and that `APPLE_SIGNING_IDENTITY` resolves to a real keychain certificate — fails in seconds with the list of valid identities and guidance, instead of minutes into the compile. No identity configured → explicit, logged ad-hoc signing.
- **Notarization stripped for local builds** (logged, with `EMBERHARMONY_NOTARIZE=1` opt-in that preflights the key file). Notarization stays a release-pipeline concern.
- **`src-tauri/rust-toolchain.toml`** pins Rust 1.93.0 — rustup honors it automatically.
- **README**: requirements table; notes that npm cannot resolve this workspace (`catalog:` protocol) — Bun only.

## Test plan

- [x] Preflight rejects the unresolvable `.env` identity fast, listing the keychain's valid identities
- [x] Full ad-hoc build end to end: `EmberHarmony Dev.app` produced (`Signature=adhoc`, hardened-runtime flag), installer DMG created
- [x] Notarization vars stripped with explicit log line