### PR TITLE
Pass EMBERHARMONY_RELEASE and EMBERHARMONY_TARGET to desktop Prepare …

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -183,6 +183,8 @@ jobs:
           RUST_TARGET: ${{ matrix.settings.target }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          EMBERHARMONY_RELEASE: ${{ inputs.release }}
+          EMBERHARMONY_TARGET: ${{ inputs.target }}
 
       # Fixes AppImage build issues, can be removed when https://github.com/tauri-apps/tauri/pull/12491 is released
       - name: Install tauri-cli from portable appimage branch


### PR DESCRIPTION
…step

Without these env vars the desktop build computed a 0.0.0-preview-* version instead of the real version from version.json, because git branch --show-current returns empty on CI's detached HEAD.