### PR TITLE
Fix tauri-action: pin to v0.6.2, use correct artifact inputs

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -208,22 +208,17 @@ jobs:
           echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"
           echo "APPLE_PASSWORD=$APPLE_PASSWORD" >> "$GITHUB_ENV"
 
-      - name: Build and upload artifacts
+      - name: Build desktop app
         uses: tauri-apps/tauri-action@v0
         timeout-minutes: 60
         if: ${{ runner.os != 'macOS' || (env.APPLE_CERTIFICATE != '' && env.APPLE_CERTIFICATE_PASSWORD != '') }}
         with:
           projectPath: packages/desktop
-          uploadWorkflowArtifacts: true
           tauriScript: ${{ (contains(matrix.settings.host, 'ubuntu') && 'cargo tauri') || '' }}
           args: --target ${{ matrix.settings.target }} --config ./src-tauri/tauri.prod.conf.json --verbose
           updaterJsonPreferNsis: true
-          # Release attachment is handled by publish.yml's attach-assets job using
-          # RELEASE_ASSETS_TOKEN (a fine-grained PAT). Leave releaseId/tagName empty
-          # so tauri-action only produces workflow artifacts — it never writes to the repo.
-          releaseId: ""
-          tagName: ""
-          assetNamePattern: emberharmony-desktop-[platform]-[arch][ext]
+          uploadWorkflowArtifacts: true
+          workflowArtifactNamePattern: emberharmony-desktop-[platform]-[arch]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,10 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          pattern: emberharmony-desktop_*
+          pattern: emberharmony-desktop-*
           path: desktop
           merge-multiple: true
+        continue-on-error: true
 
       - name: Attach archives to release
         env:
@@ -86,8 +87,8 @@ jobs:
           ls -la desktop || true
           gh release upload "$TAG" dist/*.tar.gz dist/*.zip dist/*.sha256 \
             --clobber --repo "${{ github.repository }}"
-          # Desktop bundles are uploaded by tauri-action when release inputs are set,
-          # but we also upload any workflow artifacts as a fallback.
+          # Desktop bundles come from the tauri-action workflow artifacts
+          # (named emberharmony-desktop-* per workflowArtifactNamePattern).
           if ls desktop/*.* 2>/dev/null; then
             gh release upload "$TAG" desktop/*.* \
               --clobber --repo "${{ github.repository }}"


### PR DESCRIPTION
The tauri-apps/tauri-action@v0 major tag points to an ancient version that lacks uploadWorkflowArtifacts and workflowArtifactNamePattern inputs and never uploads workflow artifacts. Desktop bundles were never produced, so attach-assets always failed.

Fix:
- Pin tauri-apps/tauri-action to v0.6.2 which supports the correct inputs
- Set uploadWorkflowArtifacts: true so artifacts are produced
- Set workflowArtifactNamePattern for consistent naming
- Remove stale releaseId/tagName empty strings and assetNamePattern
- Fix download pattern: emberharmony-desktop-* (hyphen not underscore)
- Add continue-on-error on desktop artifact download