### PR TITLE
Release 1.4.0: voice mode + security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,92 @@ All notable changes to EmberHarmony will be documented in this file.
 This project is a fork of [opencode](https://github.com/opencode-ai/opencode),
 rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmony).
 
+## [1.4.0] - 2026-06-12
+
+### Added
+
+- **Voice mode (LiveKit)** — hands-free voice conversations with sessions on the
+  desktop app. Speak to a session and hear the reply; the spoken turn runs
+  through the same model, tools, permissions, and context as a typed prompt,
+  and both sides appear in the chat. Includes a live transcript strip and an
+  agent-state visualizer in the prompt input.
+  - **Plan/build workflow** — spoken turns run the read-only `plan` agent by
+    default; a small fast model classifies explicit confirmations ("yes, do
+    it") and only then runs that single turn as `build`. A failed
+    classification can never grant execution.
+  - **Session bridge** — the voice agent worker's LLM step posts each
+    utterance to the session API and streams the reply back over SSE, so the
+    session stays the brain and voice is only ears, mouth, and transport.
+  - **Voice settings panel** — configure the LiveKit connection (credentials
+    stored in the local auth store, never config files), STT/TTS models, and
+    the intent model entirely from the UI. No environment variables required;
+    settings persist and the agent worker is managed by `emberharmony serve`.
+  - Voice follows session and project switches, reconnecting into the new
+    session's room so context always matches the visible session.
+- **`@thesolaceproject/livekit-components-solid`** — vendored SolidJS port of
+  `@livekit/components-react`, built on the framework-agnostic
+  `@livekit/components-core` (Apache-2.0, with attribution).
+
+### Security
+
+- **Biased cryptographic random fixed** — base62 ID generation in `id.ts` and
+  `util/identifier.ts` used `byte % 62`, biasing toward the first 8 of 62
+  characters; both now use rejection sampling.
+- **HTML double-unescaping fixed** — the markdown code-block decoder decoded
+  `&amp;` before `&quot;`/`&#39;`, which could double-unescape an escaped
+  entity into a real quote; `&amp;` now decodes last.
+- **CLI argument handling hardened** — `run` reassembles argv for prompt /
+  command text without shell-escaping (it never reaches a shell), choosing a
+  quote character that preserves embedded quotes and backslashes so JSON args
+  and Windows paths survive intact.
+- **Dependency CVEs patched** — esbuild bumped to ≥ 0.28.1 (binary integrity
+  verification, GHSA-gv7w-rqvm-qjhr) across the workspace and the VS Code SDK;
+  earlier in the cycle hono → 4.12.21, devalue, js-cookie, qs, ws, react-router,
+  and esbuild were bumped past fatal advisories blocking installs.
+
+### Changed
+
+- Desktop microphone support: `NSMicrophoneUsageDescription` added to the macOS
+  bundle; CSP and Tauri capabilities allow LiveKit and Tauri IPC.
+
+## [1.3.0] - 2026-05-30
+
+Reconstructed from git history (`v1.2.2..1.3.0`); grouped by theme rather than
+per-commit.
+
+### Changed
+
+- **Rebrand to the ember-flame identity** — pixel-perfect re-skin of app and
+  desktop assets, with all 15 translated READMEs re-synced to the current
+  English structure.
+- **Stripped inherited opencode/SST scaffolding** — removed the SST runtime
+  integration, Docker/AUR publishing, and unused upstream workflows and config.
+- Desktop builds drop Intel macOS (`x86_64-apple-darwin`); the local desktop
+  build is now self-contained with a declared-requirements preflight.
+
+### Added
+
+- **CI/CD overhaul** — reusable build workflow, per-merge CI, and CodeQL
+  analysis (including buildless Rust extraction). Tag-driven releases: the tag
+  names the artifacts, `version.json` names the build.
+- Mock/CI-safe provider for E2E model-picker tests; model-dependent E2E tests
+  skip on CI without provider credentials.
+
+### Security
+
+- **Supply chain** — vendor `models-snapshot.ts` instead of fetching from
+  models.dev at build time.
+- **Dependency CVEs** — nitro → 3.0.260429-beta (CVE-2026-44373); h3, astro,
+  and wrangler bumped to close 4 CVEs; turbo, tar, and rand advisories patched;
+  tauri, rustls-webpki, dompurify, and Rust crates updated.
+- **Code-scanning fixes** — server-side request forgery, uncontrolled command
+  line, biased cryptographic random, and missing workflow permissions; all
+  GitHub Actions pinned and CI locked out of default-token writes.
+
 ## [1.2.2] - 2026-04-09
 
 ### Security
+
 - **13 upstream workflows removed** — inherited from opencode fork, exposed
   `ANTHROPIC_API_KEY` and `EMBERHARMONY_API_KEY` to fork PRs via
   `pull_request_target` without fork detection, and fetched unverified code
@@ -28,6 +111,7 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 - **GitHub Actions pinned** — all 13 workflow files use commit SHA references
 
 ### Changed
+
 - README rewritten for EmberHarmony brand — removed dead links, stub package
   manager commands, and incorrect upstream references; added provider support
   section documenting Ollama auto-discovery
@@ -35,12 +119,14 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 ## [1.2.1] - 2026-04-07
 
 ### Fixed
+
 - CI: quote scoped npm package name in publish workflow (unquoted `@` broke YAML parsing)
 - CI: make publish job wait for all Tauri desktop builds before finalizing the release
 
 ## [1.2.0] - 2026-04-06
 
 ### Added
+
 - Auto-discover local Ollama models — the provider queries `localhost:11434/api/tags`
   on startup and registers every installed model with zero configuration. Display
   names include parameter size and quantization level (e.g. `llama3.2 · 3B · Q4_K_M`).
@@ -48,6 +134,7 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 ## [1.1.1] - 2026-04-06
 
 ### Fixed
+
 - Replace opencode square SVG mark/splash with ember flame icon
 - Deep link protocol `codeharmony://` → `emberharmony://` (app + desktop)
 - VS Code extension command IDs `codeharmony.*` → `emberharmony.*`
@@ -62,6 +149,7 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 ## [1.1.0] - 2026-04-06
 
 ### Added
+
 - EmberHarmony brand identity — full rebrand from upstream opencode
 - Ember flame ASCII logo with figlet "standard" font wordmark for CLI splash
 - Unified dev stack launcher (`bun run dev:stack`) — starts backend + Vite UI concurrently
@@ -69,6 +157,7 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 - `@thesolaceproject/emberharmony-plugin` package scope
 
 ### Changed
+
 - All package names moved to `@thesolaceproject/emberharmony-*` scope
 - CLI binary renamed to `emberharmony`
 - GitHub workflows, Nix derivations, and CI configs updated for new naming
@@ -76,6 +165,7 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 - Desktop app product name set to "EmberHarmony"
 
 ### Security
+
 - **minimatch** 10.0.3 → 10.2.5 — fixes 3 ReDoS vulnerabilities
 - **dompurify** 3.3.1 → 3.3.3 — fixes XSS, mutation-XSS, prototype pollution, and URI validation bypass
 - **astro** 5.15.9 → 5.18.1 — fixes remote allowlist bypass via unanchored wildcard
@@ -88,6 +178,7 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 - **react** 18.2.0 → 18.3.1, **@types/react** 18.0.25 → 18.3.28 — resolves peer dependency warnings
 
 ### Known Issues
+
 - **glib** 0.18.5 (Linux-only) — unmaintained GTK3 binding with iterator unsoundness advisory. Requires gtk4 migration to resolve; not exploitable on macOS/Windows.
 - **solid-js** pinned at 1.9.10 — version 1.9.12 removes `RequestEvent.locals` type, breaking console-app. Needs code migration before bumping.
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/app": {
       "name": "@thesolaceproject/emberharmony-app",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@shikijs/transformers": "3.9.2",
@@ -74,7 +74,7 @@
     },
     "packages/console/app": {
       "name": "@thesolaceproject/emberharmony-console-app",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -108,7 +108,7 @@
     },
     "packages/console/core": {
       "name": "@thesolaceproject/emberharmony-console-core",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@aws-sdk/client-sts": "3.933.0",
         "@jsx-email/render": "1.1.1",
@@ -135,7 +135,7 @@
     },
     "packages/console/function": {
       "name": "@thesolaceproject/emberharmony-console-function",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@ai-sdk/anthropic": "2.0.0",
         "@ai-sdk/openai": "2.0.2",
@@ -159,7 +159,7 @@
     },
     "packages/console/mail": {
       "name": "@thesolaceproject/emberharmony-console-mail",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -178,7 +178,7 @@
     },
     "packages/desktop": {
       "name": "@thesolaceproject/emberharmony-desktop",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@solid-primitives/i18n": "2.2.1",
         "@solid-primitives/storage": "catalog:",
@@ -210,7 +210,7 @@
     },
     "packages/emberharmony": {
       "name": "emberharmony",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "bin": {
         "emberharmony": "bin/emberharmony",
       },
@@ -320,7 +320,7 @@
     },
     "packages/enterprise": {
       "name": "@thesolaceproject/emberharmony-enterprise",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@pierre/diffs": "catalog:",
         "@solidjs/meta": "catalog:",
@@ -349,7 +349,7 @@
     },
     "packages/function": {
       "name": "@thesolaceproject/emberharmony-function",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "hono": "catalog:",
       },
@@ -362,7 +362,7 @@
     },
     "packages/livekit-solid": {
       "name": "@thesolaceproject/livekit-components-solid",
-      "version": "0.1.0",
+      "version": "1.4.0",
       "dependencies": {
         "@livekit/components-core": "catalog:",
         "livekit-client": "catalog:",
@@ -378,7 +378,7 @@
     },
     "packages/plugin": {
       "name": "@thesolaceproject/emberharmony-plugin",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@thesolaceproject/emberharmony-sdk": "workspace:*",
         "zod": "catalog:",
@@ -409,14 +409,14 @@
     },
     "packages/security-scanner": {
       "name": "@thesolaceproject/emberharmony-security-scanner",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "bun-osv-scanner": "2.0.0",
       },
     },
     "packages/slack": {
       "name": "@thesolaceproject/emberharmony-slack",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@slack/bolt": "^3.17.1",
         "@thesolaceproject/emberharmony-sdk": "workspace:*",
@@ -429,7 +429,7 @@
     },
     "packages/ui": {
       "name": "@thesolaceproject/emberharmony-ui",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -471,7 +471,7 @@
     },
     "packages/util": {
       "name": "@thesolaceproject/emberharmony-util",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "zod": "catalog:",
       },
@@ -482,7 +482,7 @@
     },
     "packages/web": {
       "name": "@thesolaceproject/emberharmony-web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@astrojs/cloudflare": "13.1.10",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-app",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-console-app",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@thesolaceproject/emberharmony-console-core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-console-function",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-console-mail",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thesolaceproject/emberharmony-desktop",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/emberharmony/package.json
+++ b/packages/emberharmony/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "name": "emberharmony",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-enterprise",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-function",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/livekit-solid/package.json
+++ b/packages/livekit-solid/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@thesolaceproject/livekit-components-solid",
-  "version": "0.1.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "Apache-2.0",
   "description": "SolidJS port of @livekit/components-react, built on @livekit/components-core. Vendored into EmberHarmony.",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@thesolaceproject/emberharmony-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/security-scanner/package.json
+++ b/packages/security-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-security-scanner",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-slack",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-ui",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-util",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@thesolaceproject/emberharmony-web",
   "type": "module",
   "license": "MIT",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.solace.ofharmony.ai astro dev",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "name": "EmberHarmony",
   "packageName": "@thesolaceproject/emberharmony",
   "repository": "https://github.com/SolaceHarmony/emberharmony",


### PR DESCRIPTION
Version bump and changelog for the 1.4.0 release.

## Version
- `version.json` 1.3.0 → **1.4.0**, propagated to every workspace package via `bun run version:sync` (the JS SDK and VS Code extension keep their independent versions).
- Minor bump: LiveKit voice mode is the headline new feature.

## Changelog
- **New 1.4.0 entry** — voice mode (session bridge, plan/build spoken-confirmation workflow, UI-managed config, session/project follow), the vendored `livekit-components-solid` package, and the security fixes (biased random, HTML double-unescape, CLI arg handling, esbuild/dependency CVEs).
- **Backfilled 1.3.0** — the changelog had stalled at 1.2.2, so the 1.3.0 release was undocumented. Reconstructed from `v1.2.2..1.3.0` git history and grouped by theme: ember-flame rebrand, opencode/SST scaffolding removal, CI/CD overhaul (reusable workflows, CodeQL, tag-driven releases), and the dependency/code-scanning security work. Noted inline as reconstructed.

No code changes.