### PR TITLE
Release 1.4.1: fix npm global install for the scoped CLI package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to EmberHarmony will be documented in this file.
 This project is a fork of [opencode](https://github.com/opencode-ai/opencode),
 rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmony).
 
+## [1.4.1] - 2026-06-13
+
+### Fixed
+
+- **`npm i -g @thesolaceproject/emberharmony` failed during postinstall** —
+  both the postinstall and the runtime `bin/emberharmony` wrapper derived the
+  platform binary package name by stripping the `@thesolaceproject/` scope,
+  then looked for an unscoped `emberharmony-<platform>-<arch>` that is never
+  published (the real packages are scoped, e.g.
+  `@thesolaceproject/emberharmony-darwin-arm64`). The postinstall exited 1 and
+  broke the install; the wrapper's `node_modules` walk likewise couldn't find a
+  scoped package. Both now keep the full scoped name, and the wrapper descends
+  into `node_modules/<scope>/`. (Latent since the package was scoped; only
+  surfaced now that the CLI is installed from npm rather than built locally.)
+
 ## [1.4.0] - 2026-06-12
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/app": {
       "name": "@thesolaceproject/emberharmony-app",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@shikijs/transformers": "3.9.2",
@@ -74,7 +74,7 @@
     },
     "packages/console/app": {
       "name": "@thesolaceproject/emberharmony-console-app",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -108,7 +108,7 @@
     },
     "packages/console/core": {
       "name": "@thesolaceproject/emberharmony-console-core",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@aws-sdk/client-sts": "3.933.0",
         "@jsx-email/render": "1.1.1",
@@ -135,7 +135,7 @@
     },
     "packages/console/function": {
       "name": "@thesolaceproject/emberharmony-console-function",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@ai-sdk/anthropic": "2.0.0",
         "@ai-sdk/openai": "2.0.2",
@@ -159,7 +159,7 @@
     },
     "packages/console/mail": {
       "name": "@thesolaceproject/emberharmony-console-mail",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -178,7 +178,7 @@
     },
     "packages/desktop": {
       "name": "@thesolaceproject/emberharmony-desktop",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@solid-primitives/i18n": "2.2.1",
         "@solid-primitives/storage": "catalog:",
@@ -210,7 +210,7 @@
     },
     "packages/emberharmony": {
       "name": "emberharmony",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "bin": {
         "emberharmony": "bin/emberharmony",
       },
@@ -320,7 +320,7 @@
     },
     "packages/enterprise": {
       "name": "@thesolaceproject/emberharmony-enterprise",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@pierre/diffs": "catalog:",
         "@solidjs/meta": "catalog:",
@@ -349,7 +349,7 @@
     },
     "packages/function": {
       "name": "@thesolaceproject/emberharmony-function",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "hono": "catalog:",
       },
@@ -362,7 +362,7 @@
     },
     "packages/livekit-solid": {
       "name": "@thesolaceproject/livekit-components-solid",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@livekit/components-core": "catalog:",
         "livekit-client": "catalog:",
@@ -378,7 +378,7 @@
     },
     "packages/plugin": {
       "name": "@thesolaceproject/emberharmony-plugin",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@thesolaceproject/emberharmony-sdk": "workspace:*",
         "zod": "catalog:",
@@ -409,14 +409,14 @@
     },
     "packages/security-scanner": {
       "name": "@thesolaceproject/emberharmony-security-scanner",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "bun-osv-scanner": "2.0.0",
       },
     },
     "packages/slack": {
       "name": "@thesolaceproject/emberharmony-slack",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@slack/bolt": "^3.17.1",
         "@thesolaceproject/emberharmony-sdk": "workspace:*",
@@ -429,7 +429,7 @@
     },
     "packages/ui": {
       "name": "@thesolaceproject/emberharmony-ui",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -471,7 +471,7 @@
     },
     "packages/util": {
       "name": "@thesolaceproject/emberharmony-util",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "zod": "catalog:",
       },
@@ -482,7 +482,7 @@
     },
     "packages/web": {
       "name": "@thesolaceproject/emberharmony-web",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@astrojs/cloudflare": "13.1.10",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-app",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-console-app",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@thesolaceproject/emberharmony-console-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-console-function",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-console-mail",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thesolaceproject/emberharmony-desktop",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/emberharmony/bin/emberharmony
+++ b/packages/emberharmony/bin/emberharmony
@@ -30,8 +30,10 @@ function readPackageName() {
   try {
     const pkgPath = path.join(scriptDir, "..", "package.json")
     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
-    const name = typeof pkg.name === "string" ? pkg.name : "emberharmony"
-    return name.includes("/") ? name.split("/").pop() : name
+    // Keep the full name including any scope: platform binary packages are
+    // published as `<name>-<platform>-<arch>` off this exact name (e.g.
+    // `@thesolaceproject/emberharmony-darwin-arm64`).
+    return typeof pkg.name === "string" ? pkg.name : "emberharmony"
   } catch {
     return "emberharmony"
   }
@@ -119,17 +121,26 @@ if (!arch) {
 const base = readPackageName() + "-" + platform + "-" + arch
 const binary = platform === "windows" ? "emberharmony.exe" : "emberharmony"
 
+// `base` may be scoped (e.g. "@thesolaceproject/emberharmony-darwin-arm64").
+// Scoped packages live under node_modules/<scope>/, so split off the scope and
+// match the remaining prefix (which still catches -baseline/-musl variants)
+// against the directory entries inside that scope.
+const baseSlash = base.lastIndexOf("/")
+const baseScope = baseSlash === -1 ? "" : base.slice(0, baseSlash)
+const basePrefix = baseSlash === -1 ? base : base.slice(baseSlash + 1)
+
 function findBinary(startDir) {
   let current = startDir
   for (;;) {
     const modules = path.join(current, "node_modules")
-    if (fs.existsSync(modules)) {
-      const entries = fs.readdirSync(modules)
+    const searchDir = baseScope ? path.join(modules, baseScope) : modules
+    if (fs.existsSync(searchDir)) {
+      const entries = fs.readdirSync(searchDir)
       for (const entry of entries) {
-        if (!entry.startsWith(base)) {
+        if (!entry.startsWith(basePrefix)) {
           continue
         }
-        const candidate = path.join(modules, entry, "bin", binary)
+        const candidate = path.join(searchDir, entry, "bin", binary)
         if (fs.existsSync(candidate)) {
           return candidate
         }

--- a/packages/emberharmony/package.json
+++ b/packages/emberharmony/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "name": "emberharmony",
   "type": "module",
   "license": "MIT",

--- a/packages/emberharmony/script/postinstall.mjs
+++ b/packages/emberharmony/script/postinstall.mjs
@@ -13,8 +13,11 @@ function readPackageName() {
   try {
     const pkgPath = path.join(__dirname, "package.json")
     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
-    const name = typeof pkg.name === "string" ? pkg.name : "emberharmony"
-    return name.includes("/") ? name.split("/").pop() : name
+    // Keep the full name including any scope: the platform binary packages are
+    // published as `<name>-<platform>-<arch>` off this exact name (e.g.
+    // `@thesolaceproject/emberharmony-darwin-arm64`). Stripping the scope here
+    // would look for an unscoped `emberharmony-darwin-arm64` that does not exist.
+    return typeof pkg.name === "string" ? pkg.name : "emberharmony"
   } catch {
     return "emberharmony"
   }

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-enterprise",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-function",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/livekit-solid/package.json
+++ b/packages/livekit-solid/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@thesolaceproject/livekit-components-solid",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "Apache-2.0",
   "description": "SolidJS port of @livekit/components-react, built on @livekit/components-core. Vendored into EmberHarmony.",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@thesolaceproject/emberharmony-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/security-scanner/package.json
+++ b/packages/security-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-security-scanner",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-slack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesolaceproject/emberharmony-util",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@thesolaceproject/emberharmony-web",
   "type": "module",
   "license": "MIT",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.solace.ofharmony.ai astro dev",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.1",
   "name": "EmberHarmony",
   "packageName": "@thesolaceproject/emberharmony",
   "repository": "https://github.com/SolaceHarmony/emberharmony",


### PR DESCRIPTION
## Bug
`npm i -g @thesolaceproject/emberharmony@latest` fails:
```
Failed to setup emberharmony binary: Could not find package emberharmony-darwin-arm64:
Cannot find module 'emberharmony-darwin-arm64/package.json' from '.../postinstall.mjs'
```

## Cause
Both `postinstall.mjs` and the runtime `bin/emberharmony` wrapper derived the platform binary package name via `readPackageName()`, which **stripped the `@thesolaceproject/` scope** (`name.split("/").pop()`), then looked for an unscoped `emberharmony-<platform>-<arch>`. The published platform packages are scoped — `@thesolaceproject/emberharmony-darwin-arm64` — so:
- the postinstall's `require.resolve` threw and exited 1, **breaking the install**;
- the wrapper's `node_modules` walk read only top-level entries (sees `@thesolaceproject`, never `emberharmony-darwin-arm64`), so even a succeeding install wouldn't run.

Latent since the package became scoped; surfaced now because this is the first time the CLI was installed from npm rather than built locally / run via the desktop app.

## Fix
- `readPackageName()` (both files) keeps the **full scoped name**.
- The wrapper's `findBinary` splits off the scope and searches `node_modules/<scope>/`, still prefix-matching `-baseline`/`-musl` variants.

Verified end-to-end against a simulated scoped install layout: postinstall exits 0 and verifies the scoped platform package; the wrapper resolves and runs the binary. Both scripts pass `node --check`.

## Release
Bumps to **1.4.1** (1.4.0 is immutable on npm and broken). version.json synced across all workspace packages + `bun.lock`; changelog entry added. After this reaches `main` (dev→main), cut the v1.4.1 release to republish a working npm package.