### PR TITLE
wrapper: select platform binary by variant priority (fixes musl/baseline mis-selection + readdir crash)

### DIFF
--- a/packages/emberharmony/bin/emberharmony
+++ b/packages/emberharmony/bin/emberharmony
@@ -134,16 +134,21 @@ function findBinary(startDir) {
   for (;;) {
     const modules = path.join(current, "node_modules")
     const searchDir = baseScope ? path.join(modules, baseScope) : modules
-    if (fs.existsSync(searchDir)) {
-      const entries = fs.readdirSync(searchDir)
-      for (const entry of entries) {
-        if (!entry.startsWith(basePrefix)) {
-          continue
-        }
-        const candidate = path.join(searchDir, entry, "bin", binary)
-        if (fs.existsSync(candidate)) {
-          return candidate
-        }
+    // Tolerate searchDir being absent, a file (ENOTDIR), or unreadable
+    // (EACCES): skip it and keep walking up rather than crashing the wrapper.
+    let entries = []
+    try {
+      entries = fs.readdirSync(searchDir)
+    } catch {
+      entries = []
+    }
+    for (const entry of entries) {
+      if (!entry.startsWith(basePrefix)) {
+        continue
+      }
+      const candidate = path.join(searchDir, entry, "bin", binary)
+      if (fs.existsSync(candidate)) {
+        return candidate
       }
     }
     const parent = path.dirname(current)


### PR DESCRIPTION
Addresses the review comment on #100 (`bin/emberharmony` `findBinary`).

`findBinary` checked `existsSync` then called `readdirSync`, which throws — and crashes the CLI wrapper with a raw stack trace — when the path exists but is a file (`ENOTDIR`) or is unreadable (`EACCES`), instead of skipping it and continuing up the directory tree to the helpful "package manager failed to install" message.

Guard the single `readdirSync` in a try/catch (and drop the now-redundant `existsSync`). Verified: `node --check` passes, the happy path still resolves the scoped platform binary, and it now walks *past* an ancestor that has a **file** named `node_modules` (the ENOTDIR case) instead of crashing.

Pre-existing pattern, not a regression — but the CLI entry point shouldn't crash on a hostile/odd filesystem. No version change; folds into the unreleased 1.4.1.