### PR TITLE
Derive macOS signing identity from cert (fix notarization skip)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -183,7 +183,18 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
           # Prepend the keychain to the search list so codesign resolves the identity.
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed 's/"//g')
-          bun packages/desktop/scripts/sign-voice-runtime.ts --identity "$APPLE_SIGNING_IDENTITY" --keychain "$KEYCHAIN"
+          # APPLE_SIGNING_IDENTITY is unset in this repo — tauri-action auto-derives
+          # it from the imported cert, so we must too, or the signer silently skips
+          # (which is exactly what shipped unsigned nested binaries to notarization).
+          IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+          if [ -z "$IDENTITY" ] || [ "$IDENTITY" = "-" ]; then
+            IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" | sed -nE 's/^[[:space:]]*[0-9]+\)[[:space:]]+[0-9A-F]+[[:space:]]+"(Developer ID Application: .*)"$/\1/p' | head -1)"
+          fi
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::no Developer ID Application identity in the signing keychain"; exit 1
+          fi
+          echo "Signing voice runtime with identity: $IDENTITY"
+          bun packages/desktop/scripts/sign-voice-runtime.ts --identity "$IDENTITY" --keychain "$KEYCHAIN"
           rm -f "$CERT"
 
       - name: Build desktop app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 
 ### Fixed
 
+- **macOS notarization rejected the unsigned voice-runtime binaries** — the CI
+  step that signs the bundled native binaries passed
+  `--identity "$APPLE_SIGNING_IDENTITY"`, but that secret is intentionally unset
+  in this repo (it is optional; `tauri-action` auto-derives the identity from
+  the imported `APPLE_CERTIFICATE`). With an empty identity the signer took its
+  ad-hoc "skip" path, so every nested `.node`/`.dylib`/`ffmpeg` shipped unsigned
+  and notarization failed with "not signed with a valid Developer ID
+  certificate". The step now derives the Developer ID identity from the imported
+  cert in its keychain and fails loudly if none is found, instead of skipping.
 - **Windows desktop build failed packaging the voice runtime** — the bundled
   runtime's `node_modules` was installed with bun, whose standalone install
   deep-nests `@livekit/agents`' genuinely-conflicting `@opentelemetry`


### PR DESCRIPTION
## What & why

macOS notarization has been failing on every release run (1.4.5, 1.4.6) with the bundled voice-runtime native binaries reported as "not signed with a valid Developer ID certificate". The cause: the CI sign step ran

```
sign-voice-runtime.ts --identity "$APPLE_SIGNING_IDENTITY"
```

but **`APPLE_SIGNING_IDENTITY` is not a configured secret in this repo** (only `APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` + the App Store Connect API-key secrets exist). `APPLE.md` documents `APPLE_SIGNING_IDENTITY` as *optional* — `tauri-action` auto-derives the identity from the imported cert. My step didn't, so it got an empty identity and the signer took its ad-hoc **skip** path → the nested `.node`/`.dylib`/`ffmpeg` shipped **unsigned** → notary rejects them.

(The signing logic itself was only ever verified locally, where I passed the identity by hand. It has never actually run in CI. Correcting an earlier wrong call that the 1.4.5 macOS failure was a transient notary flake.)

## Fix

In `_build.yml`, after importing `APPLE_CERTIFICATE` into the throwaway keychain, derive the `Developer ID Application: …` identity from that keychain via `security find-identity` (prefer the secret only if set), and **fail loudly** if no identity is found instead of skipping. Verified the extraction parse locally.

## Status

- ✅ **Windows passed** on the 1.4.6 run — the npm/MAX_PATH fix is proven.
- ✅ Linux builds clean.
- ⏳ macOS — this PR. The real proof is the next release run (CI keychain behavior can't be fully reproduced locally).

## Release

The `v1.4.6` tag was deleted (nothing published under it), and `version.json` is still 1.4.6. Recommend: merge → promote `dev` → re-tag `v1.4.6` to re-cut cleanly with no version churn.