### PR TITLE
Retry flaky HuggingFace model download in voice assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 
 ### Fixed
 
+- **Voice-runtime build aborted on a flaky HuggingFace model download** — the
+  assembler's `download-files` step had no retry, so a single transient
+  HuggingFace error (rate limiting surfaces as
+  "tokenizerConfig.tokenizer_class undefined" when a non-JSON response is parsed
+  as the turn-detector tokenizer config) failed the whole build. The download
+  now retries with backoff and only fails loudly after exhausting attempts.
 - **macOS notarization rejected the unsigned voice-runtime binaries** — the CI
   step that signs the bundled native binaries passed
   `--identity "$APPLE_SIGNING_IDENTITY"`, but that secret is intentionally unset

--- a/packages/desktop/scripts/build-voice-runtime.ts
+++ b/packages/desktop/scripts/build-voice-runtime.ts
@@ -158,10 +158,23 @@ console.log("[voice-runtime] downloading ONNX models")
 const modelsDir = path.join(outDir, "models")
 await mkdir(modelsDir, { recursive: true })
 const modelEnv = { ...process.env, HF_HOME: modelsDir, XDG_CACHE_HOME: modelsDir, BUN_SECURITY_SCAN: "0" }
-await $`bun run ${path.join(outDir, "agent.js")} download-files`
-  .cwd(outDir)
-  .env(modelEnv)
-  .quiet()
+// HuggingFace downloads flake — rate limits and transient errors surface as
+// e.g. "tokenizerConfig.tokenizer_class undefined" (a non-JSON response parsed
+// as the tokenizer config). A single flake otherwise aborts the whole build,
+// so retry with backoff and only fail loudly once attempts are exhausted.
+const MODEL_DL_ATTEMPTS = 4
+for (let attempt = 1; ; attempt++) {
+  const res = await $`bun run ${path.join(outDir, "agent.js")} download-files`.cwd(outDir).env(modelEnv).quiet().nothrow()
+  if (res.exitCode === 0) break
+  if (attempt >= MODEL_DL_ATTEMPTS) {
+    throw new Error(
+      `[voice-runtime] model download failed after ${MODEL_DL_ATTEMPTS} attempts:\n${(res.stderr.toString() || res.stdout.toString()).trim()}`,
+    )
+  }
+  const backoffSec = attempt * 5
+  console.log(`[voice-runtime] model download attempt ${attempt}/${MODEL_DL_ATTEMPTS} failed; retrying in ${backoffSec}s`)
+  await Bun.sleep(backoffSec * 1000)
+}
 
 // --- 3b. Prune the staged node_modules to runtime-only -------------------
 // The install pulls heavy transitive deps the worker never loads. Drop the


### PR DESCRIPTION
## What & why

A release/assembly run failed with:

```
FATAL Error during file downloads: Failed to download files for 1 plugin:
- turn-detector (@livekit/agents-plugin-livekit@1.4.5): undefined is not an object (evaluating 'tokenizerConfig.tokenizer_class')
```

Silero VAD downloaded fine; only the turn-detector failed. Diagnosis:

- `agents-plugin-livekit@1.4.5` **pins** `@huggingface/transformers@4.2.0`, and that's what's installed — **not** a version mismatch (npm and bun both resolve 4.2.0).
- The error is a **transient HuggingFace flake** (rate limiting — we'd pulled this model dozens of times today): a non-JSON error response gets parsed as the tokenizer config, so `tokenizerConfig` is `undefined`.
- **Confirmed transient:** re-running `download-files` with a fresh cache succeeded immediately, same versions.

The real defect is that `build-voice-runtime.ts` had **no retry** around the download, so one flake aborts the whole build.

## Fix

Wrap the model download in a bounded retry (4 attempts, 5/10/15 s backoff) and **fail loudly** with captured output only after attempts are exhausted. Script still bundles clean.

## Context

This stacks on the macOS signing fix (#114, already on `dev`). Together with the proven Windows/npm fix, this clears the known assembly/build flakes for the `v1.4.6` re-cut.