### PR TITLE
Drop AppImage (Linux deb+rpm only) and gate full builds to tags

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -133,14 +133,6 @@ jobs:
           EMBERHARMONY_RELEASE: ${{ inputs.release }}
           EMBERHARMONY_TARGET: ${{ inputs.target }}
 
-      # Fixes AppImage build issues, can be removed when https://github.com/tauri-apps/tauri/pull/12491 is released
-      - name: Install tauri-cli from portable appimage branch
-        if: contains(matrix.settings.host, 'ubuntu')
-        run: |
-          cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
-          echo "Installed tauri-cli version:"
-          cargo tauri --version
-
       - name: Write Apple API key
         if: runner.os == 'macOS'
         shell: bash
@@ -202,7 +194,6 @@ jobs:
         timeout-minutes: 60
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: true
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -214,8 +205,11 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: packages/desktop
-          tauriScript: ${{ (contains(matrix.settings.host, 'ubuntu') && 'cargo tauri') || '' }}
-          args: --target ${{ matrix.settings.target }} --config ./src-tauri/tauri.prod.conf.json
+          # Linux ships deb + rpm only. AppImage bundling stalls on x64 (hangs on
+          # the AppImage runtime/FUSE step with no timeout → 60-min build timeout)
+          # and isn't in the configured bundle.targets anyway; pin --bundles so it
+          # can never be attempted.
+          args: ${{ contains(matrix.settings.host, 'ubuntu') && '--bundles deb,rpm ' || '' }}--target ${{ matrix.settings.target }} --config ./src-tauri/tauri.prod.conf.json
           updaterJsonPreferNsis: true
 
       - name: Upload desktop artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: CI
 run-name: CI ${{ github.ref_name }} @ ${{ github.sha }}
 
-# Verification builds. Runs the CLI build on every push to an integration branch
-# (i.e. after a PR merges). Does NOT run on pull_request — that keeps the
-# expensive release build off PR review.
+# Full desktop/CLI build. This is expensive (4-platform Tauri builds), so it
+# does NOT run on every push — type-checking (typecheck.yml) covers per-push
+# verification. Run it intentionally: push a dev-channel tag (dev-v*) for a dev
+# build, or trigger manually. Release builds go through publish.yml on a
+# published GitHub release.
 
 on:
   push:
-    branches: [main, dev]
+    tags:
+      - "dev-v*"
   workflow_dispatch:
 
 # Every merge commit deserves its own verification — do not cancel in progress.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 
 ### Changed
 
+- **Linux desktop ships `.deb` + `.rpm` only (AppImage dropped).** AppImage
+  bundling stalls on x86_64 — the AppImage runtime/FUSE step hangs with no
+  timeout, burning the full 60-minute build limit (arm64 took ~18 min but
+  eventually finished it). It also wasn't in the configured bundle targets. The
+  build now pins `--bundles deb,rpm` on Linux and drops the custom
+  `truly-portable-appimage` tauri-cli, which also removes a ~5-minute
+  per-Linux-build `cargo install` step.
 - The voice-runtime assembler now reads the `@livekit/*` versions from the
   workspace catalog and the Bun version from `packageManager`, instead of
   hardcoding them — so the bundled runtime can no longer silently drift from

--- a/packages/desktop/scripts/build-voice-runtime.ts
+++ b/packages/desktop/scripts/build-voice-runtime.ts
@@ -167,9 +167,10 @@ for (let attempt = 1; ; attempt++) {
   const res = await $`bun run ${path.join(outDir, "agent.js")} download-files`.cwd(outDir).env(modelEnv).quiet().nothrow()
   if (res.exitCode === 0) break
   if (attempt >= MODEL_DL_ATTEMPTS) {
-    throw new Error(
-      `[voice-runtime] model download failed after ${MODEL_DL_ATTEMPTS} attempts:\n${(res.stderr.toString() || res.stdout.toString()).trim()}`,
-    )
+    // download-files logs the real error to stdout; keep both streams so a
+    // stray stderr warning can't hide it.
+    const output = [res.stderr.toString().trim(), res.stdout.toString().trim()].filter(Boolean).join("\n\n")
+    throw new Error(`[voice-runtime] model download failed after ${MODEL_DL_ATTEMPTS} attempts:\n${output}`)
   }
   const backoffSec = attempt * 5
   console.log(`[voice-runtime] model download attempt ${attempt}/${MODEL_DL_ATTEMPTS} failed; retrying in ${backoffSec}s`)

--- a/packages/desktop/scripts/build-voice-runtime.ts
+++ b/packages/desktop/scripts/build-voice-runtime.ts
@@ -168,8 +168,10 @@ for (let attempt = 1; ; attempt++) {
   if (res.exitCode === 0) break
   if (attempt >= MODEL_DL_ATTEMPTS) {
     // download-files logs the real error to stdout; keep both streams so a
-    // stray stderr warning can't hide it.
-    const output = [res.stderr.toString().trim(), res.stdout.toString().trim()].filter(Boolean).join("\n\n")
+    // stray stderr warning can't hide it, with a fallback if both are empty.
+    const output =
+      [res.stderr.toString().trim(), res.stdout.toString().trim()].filter(Boolean).join("\n\n") ||
+      "(no output captured from stdout or stderr)"
     throw new Error(`[voice-runtime] model download failed after ${MODEL_DL_ATTEMPTS} attempts:\n${output}`)
   }
   const backoffSec = attempt * 5


### PR DESCRIPTION
## Two changes

### 1. Drop AppImage — fixes the x86_64 build hang
The Linux x64 release build hung for **58 minutes of zero output** after producing deb+rpm, then hit the 60-min timeout. Confirmed it's **AppImage bundling**: arm64 (which passed) shows AppImage took ~18 min before finishing; x64 stalls on the AppImage runtime/FUSE step with no internal timeout. AppImage wasn't even in the configured `bundle.targets` — it was forced by the custom `truly-portable-appimage` tauri-cli + `TAURI_BUNDLER_NEW_APPIMAGE_FORMAT`.

- Remove the custom tauri-cli install step (also saves ~5 min/Linux build) and the new-format env.
- Pin `--bundles deb,rpm` on Linux so AppImage can never be attempted.
- Linux now ships **deb + rpm** (+ the CLI tarball). AppImage can be revisited if/when the upstream tauri AppImage path stabilizes.

### 2. Stop full builds on every push
`ci.yml` was running the **expensive 4-platform Tauri build on every push to main/dev** — the bulk of the Actions usage. Now:
- Full build runs only on a **`dev-v*` tag** or **manual dispatch**.
- **Release** builds still run via `publish.yml` on a published release.
- **Per-push verification stays as type-checking** (`typecheck.yml`) — unchanged.

## Notes
- Both YAML files validated.
- No functional AppImage references remain (only explanatory comments).
- This is part of the `v1.4.6` re-cut: merge → promote `dev` → `main` → re-tag `v1.4.6`. With AppImage gone, all four platform builds should complete (macOS already notarized, Windows already built).