### PR TITLE
Fix voice breaking on every tool use (operation aborted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmon
 
 ### Fixed
 
+- **Voice broke on every tool use ("operation aborted")** — the session bridge
+  ended a voice reply as soon as the first assistant message completed. But a
+  tool-call step finalizes its message (`time.completed`, `finish: "tool-calls"`)
+  *before* the tool runs, then opens a new assistant message for the result. So
+  the bridge returned mid-tool, its stream closed, the abort handler POSTed
+  `/session/abort`, and the server killed the running tool — voice then went
+  silent (though still listening) because the continuation never streamed. The
+  bridge now streams text from every assistant message in the turn (under one
+  stable id, so TTS stays continuous) and ends only when the session goes idle.
 - **Voice-runtime build aborted on a flaky HuggingFace model download** — the
   assembler's `download-files` step had no retry, so a single transient
   HuggingFace error (rate limiting surfaces as

--- a/packages/emberharmony/src/voice/bridge.ts
+++ b/packages/emberharmony/src/voice/bridge.ts
@@ -149,14 +149,24 @@ export class SessionLLMStream extends llm.LLMStream {
       throw new Error(`session prompt failed: ${response.status} ${await response.text().catch(() => "")}`)
     }
 
-    // The reply is whichever message in this session streams text deltas next.
-    // User-message parts are created whole (no delta), so they never match.
+    // A turn can span several assistant messages: a tool-call step finalizes
+    // its message (sets time.completed) BEFORE the tool runs, then the next
+    // step opens a fresh assistant message for the post-tool reply. So we
+    // stream text from every assistant message in this session — under one
+    // stable id so TTS speaks it as one continuous utterance — and end the
+    // turn only when the session returns to idle.
+    //
+    // Ending on a single message's completion (the old behaviour) cut the reply
+    // off the instant the first tool-call message finalized: this stream closed,
+    // its abort handler POSTed /abort, and the server killed the still-running
+    // tool ("operation aborted") while the continuation never streamed.
+    //
     // The server emits heartbeats every 30s, so this loop always wakes even
-    // when the session goes quiet — the staleness check turns a reply that
-    // never starts (or never finishes) into an error instead of a worker hang.
+    // when the session goes quiet; the staleness check turns a reply that never
+    // starts (or never finishes) into an error instead of a worker hang.
     const STALE_MS = 120_000
     let lastActivity = Date.now()
-    let replyMessageID: string | undefined
+    let replyId: string | undefined
     for await (const event of events) {
       if (Date.now() - lastActivity > STALE_MS) {
         throw new Error(`session reply timed out (no session events for ${STALE_MS / 1000}s)`)
@@ -166,17 +176,17 @@ export class SessionLLMStream extends llm.LLMStream {
         if (!part || part.sessionID !== this.#opts.sessionID) continue
         lastActivity = Date.now()
         if (part.type !== "text" || !delta) continue
-        if (!replyMessageID) replyMessageID = part.messageID
-        if (part.messageID !== replyMessageID) continue
-        this.queue.put({ id: replyMessageID!, delta: { role: "assistant", content: delta } })
+        if (!replyId) replyId = part.messageID
+        this.queue.put({ id: replyId!, delta: { role: "assistant", content: delta } })
       }
       if (event.type === "message.updated") {
-        const info = event.properties?.info
-        if (!info || info.sessionID !== this.#opts.sessionID) continue
-        lastActivity = Date.now()
-        if (replyMessageID && info.id === replyMessageID && info.time?.completed) return
-        // reply finished with no text at all (e.g. aborted server-side)
-        if (!replyMessageID && info.role === "assistant" && info.time?.completed) return
+        if (event.properties?.info?.sessionID === this.#opts.sessionID) lastActivity = Date.now()
+      }
+      // The whole turn — every step and tool call — is done only when the
+      // session goes idle (also fires on server-side cancel, which ends the
+      // turn just the same).
+      if (event.type === "session.idle" && event.properties?.sessionID === this.#opts.sessionID) {
+        return
       }
       if (event.type === "session.error") {
         const props = event.properties ?? {}

--- a/packages/emberharmony/src/voice/bridge.ts
+++ b/packages/emberharmony/src/voice/bridge.ts
@@ -161,9 +161,11 @@ export class SessionLLMStream extends llm.LLMStream {
     // its abort handler POSTed /abort, and the server killed the still-running
     // tool ("operation aborted") while the continuation never streamed.
     //
-    // The server emits heartbeats every 30s, so this loop always wakes even
-    // when the session goes quiet; the staleness check turns a reply that never
-    // starts (or never finishes) into an error instead of a worker hang.
+    // The server emits a heartbeat every 30s, which bumps the activity clock —
+    // so the staleness check only fires when the SSE connection itself goes
+    // dead (no heartbeat for STALE_MS), turning a silently-dropped stream into
+    // an error instead of a worker hang. A long-running tool keeps the stream
+    // alive via those heartbeats, so it never trips this.
     const STALE_MS = 120_000
     let lastActivity = Date.now()
     let replyId: string | undefined
@@ -182,6 +184,10 @@ export class SessionLLMStream extends llm.LLMStream {
       if (event.type === "message.updated") {
         if (event.properties?.info?.sessionID === this.#opts.sessionID) lastActivity = Date.now()
       }
+      // Heartbeats (every 30s) prove the SSE connection is alive even while a
+      // long tool runs with no message events — bump activity so the staleness
+      // check only trips on a genuinely dead connection, not a slow tool.
+      if (event.type === "server.heartbeat") lastActivity = Date.now()
       // The whole turn — every step and tool call — is done only when the
       // session goes idle (also fires on server-side cancel, which ends the
       // turn just the same).


### PR DESCRIPTION
## Symptom
On the desktop app, voice works — but the moment the agent uses a **tool**, the tool reports "operation aborted" and voice goes silent (still listening, but the conversation stops).

## Root cause
The session bridge (`voice/bridge.ts`) ended a voice reply as soon as the **first** assistant message completed:

```ts
if (replyMessageID && info.id === replyMessageID && info.time?.completed) return
```

But a tool call doesn't finish the turn — `prompt.ts` finalizes the tool-call message *before* the tool runs:

```ts
assistantMessage.finish = "tool-calls"
assistantMessage.time.completed = Date.now()   // message "completes", tool hasn't run yet
```

…then opens a **new** assistant message for the post-tool reply. So the bridge:
1. saw the first message complete → `return`ed mid-tool,
2. its `LLMStream` closed → the abort handler fired `POST /session/abort`,
3. the server killed the still-running tool → **"operation aborted"**,
4. the continuation (second message) never streamed → voice went silent.

Deterministic on every tool use, exactly as reported.

## Fix
- **Stream text from every assistant message in the turn** (not just the first), under one stable id so TTS speaks it as one continuous utterance with a natural pause during the tool.
- **End the turn on `session.idle`**, not on a single message's completion. `session.idle` is reliable for normal completion too: `prompt.ts` does `using _ = defer(() => cancel(sessionID))`, and `cancel()` sets idle on every prompt exit.
- Tool-/part-update events still bump the staleness clock, so a long tool won't trip the 120 s no-activity timeout.

Real voice interruptions still abort (the user speaking → abort → `/session/abort` is intended); this only removes the *false* abort that tool execution triggered.

## Verification
- Typecheck passes.
- Logic verified against `prompt.ts` step/finish model and the deferred `cancel()` → idle path.
- Live mic test (speak → agent runs a tool → hears the full answer) needs the desktop app — that's the real confirmation.

Folds into the in-flight **1.4.6** (same as the other voice/release fixes).