### PR TITLE
Drop dead AppImage references; pass dev-channel build inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ permissions:
   actions: read
 
 jobs:
-  # No version job: artifacts carry the version from packages/emberharmony/package.json
-  # at build time. release and tag are omitted, so _build.yml produces workflow
-  # artifacts only — no GitHub release attachment, and nothing commits, tags, or pushes.
+  # `release` is omitted, so _build.yml produces workflow artifacts only — no
+  # GitHub release attachment, nothing commits/tags/pushes. `tag`/`target` mark
+  # these as dev-channel builds (the trigger is a dev-v* tag or manual dispatch).
   build:
     uses: ./.github/workflows/_build.yml
     secrets: inherit
+    with:
+      target: dev
+      tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,10 +120,8 @@ jobs:
           stage 'EmberHarmony_*_aarch64.dmg'    emberharmony-desktop-darwin-aarch64.dmg
           stage 'EmberHarmony_*_x64-setup.exe'  emberharmony-desktop-windows-x64.exe
           stage 'EmberHarmony_*_amd64.deb'      emberharmony-desktop-linux-amd64.deb
-          stage 'EmberHarmony_*_amd64.AppImage' emberharmony-desktop-linux-amd64.AppImage
           stage 'EmberHarmony*x86_64.rpm'       emberharmony-desktop-linux-x86_64.rpm
           stage 'EmberHarmony_*_arm64.deb'      emberharmony-desktop-linux-arm64.deb
-          stage 'EmberHarmony_*_arm64.AppImage' emberharmony-desktop-linux-arm64.AppImage
           stage 'EmberHarmony*aarch64.rpm'      emberharmony-desktop-linux-arm64.rpm
 
       - name: Attach archives to release

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ EmberHarmony is also available as a desktop application. Download directly from 
 | macOS (Apple Silicon) | `emberharmony-desktop-darwin-aarch64.dmg` |
 | macOS (Intel)         | `emberharmony-desktop-darwin-x64.dmg`     |
 | Windows               | `emberharmony-desktop-windows-x64.exe`    |
-| Linux                 | `.deb`, `.rpm`, or AppImage               |
+| Linux                 | `.deb` or `.rpm`                          |
 
 #### Installation Directory
 


### PR DESCRIPTION
Follow-up to #118, addressing two **P2** review comments from `chatgpt-codex-connector` that were missed on that PR (only Gemini's surfaced).

## Changes
- **`publish.yml`** — stop staging the Linux `*.AppImage` artifacts that are no longer built. (`stage()` already skips missing files, so this was harmless dead code, not a release blocker — the v1.4.6 publish is safe either way.)
- **`README.md`** — Linux download row now reads `.deb` or `.rpm` (no AppImage).
- **`ci.yml`** — the `dev-v*` / dispatch build now passes `target: dev` and the tag to `_build.yml`, so dev-channel builds are marked as such instead of invoking the reusable build with empty channel inputs.

## Not blocking the release
The v1.4.6 publish path (`publish.yml`) handles missing AppImage gracefully, so this is pure cleanup — it can land before or after the re-cut.