### PR TITLE
fix(build): stop shipping ~37MB of sourcemaps in release packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to EmberHarmony will be documented in this file.
 This project is a fork of [opencode](https://github.com/opencode-ai/opencode),
 rebranded and maintained by [The Solace Project](https://github.com/SolaceHarmony).
 
+## [Unreleased]
+
+### Changed
+
+- **~37 MB smaller install per platform.** The published platform packages
+  (`@thesolaceproject/emberharmony-<os>-<arch>`) were shipping the external
+  `*.js.map` sourcemaps Bun emits next to the compiled binary (~37 MB:
+  `index.js.map` 20 MB + `worker.js.map` 16 MB + `parser.worker.js.map`) — dead
+  weight the standalone executable never loads at runtime. Two changes:
+  - **Release builds no longer generate external sourcemaps.** `build.ts` now
+    sets `sourcemap: "none"` whenever `EMBERHARMONY_RELEASE` is set (every
+    npm-published build, `latest` and `dev` channels alike); local/branch dev
+    builds keep `external` maps for debugging. This also shrinks the GitHub
+    release archives and speeds release builds.
+  - **Defense-in-depth `files` allowlist** on each platform package manifest
+    (binary + `RELEASE_NOTES.md`), so a platform tarball can only ever contain
+    the executable regardless of what else lands in `dist/<pkg>/bin/`.
+
+  Net: a darwin-arm64 global install drops from ~135 MB to ~98 MB, and ~440 MB
+  of dead sourcemaps stop being stored across all 12 platform packages.
+
 ## [1.4.7] - 2026-06-20
 
 ### Added

--- a/packages/emberharmony/script/build.ts
+++ b/packages/emberharmony/script/build.ts
@@ -175,7 +175,12 @@ for (const item of targets) {
     conditions: ["browser"],
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
-    sourcemap: "external",
+    // Release builds (any npm-published channel — EMBERHARMONY_RELEASE is set
+    // for both `latest` and `dev` releases) emit no external sourcemaps: the
+    // standalone compiled binary never loads them at runtime, so they were only
+    // ~37 MB of dead weight per platform package. Local/branch dev builds keep
+    // external maps for debugging.
+    sourcemap: Script.release ? "none" : "external",
     compile: {
       autoloadBunfig: false,
       autoloadDotenv: false,
@@ -200,6 +205,7 @@ for (const item of targets) {
 
   await $`rm -rf ./dist/${name}/bin/tui`
   const packageName = name.replace(pkg.name, publishName)
+  const binaryFile = `${cliName}${item.os === "win32" ? ".exe" : ""}`
   await Bun.file(`dist/${name}/package.json`).write(
     JSON.stringify(
       {
@@ -207,6 +213,19 @@ for (const item of targets) {
         version: Script.version,
         os: [item.os],
         cpu: [item.arch],
+        // Ship only the executable (+ release notes when they're actually
+        // written — see the EMBERHARMONY_RELEASE_NOTES block below). Without this
+        // allowlist, bun/npm pack includes everything in bin/ — notably the
+        // ~37 MB of external `*.js.map` sourcemaps Bun emits next to the compiled
+        // binary, which the standalone executable never loads at runtime. The
+        // maps stay on disk in dist/ for release archives; they just don't ship
+        // to npm. RELEASE_NOTES.md is gated on the same condition that creates it
+        // so the allowlist never names a missing file (dev builds, or releases
+        // published without notes).
+        files: [
+          `bin/${binaryFile}`,
+          ...(Script.release && process.env.EMBERHARMONY_RELEASE_NOTES ? ["bin/RELEASE_NOTES.md"] : []),
+        ],
       },
       null,
       2,


### PR DESCRIPTION
## Problem

Inspecting a real `npm i -g @thesolaceproject/emberharmony@1.4.7` global install: each platform package ships the external sourcemaps Bun emits next to the compiled binary —

```
bin/emberharmony          98 MB   ← the binary (needed)
bin/index.js.map          20 MB   ← dead weight
bin/worker.js.map         16 MB   ← dead weight
bin/parser.worker.js.map  289 KB  ← dead weight
```

~37 MB per platform that the **standalone compiled binary never loads at runtime** (~440 MB across all 12 platform packages on the registry). A darwin-arm64 global install is 135 MB when it should be ~98 MB.

> Note: confirmed the published tarballs contain **no `.env`, `.npmrc`, or secrets** — only the binary + maps + README/LICENSE. This was bloat, not exposure.

## Fix (build-level, leveraging the existing dev/release split)

No workflow edit needed — the signal already flows: `publish.yml` → `_build.yml` sets `EMBERHARMONY_RELEASE` → `Script.release`.

- **`build.ts`: `sourcemap: "none"` for release builds** (`EMBERHARMONY_RELEASE` set — every npm-published build, `latest` and `dev` channels). Local/branch dev builds keep `external` maps for debugging. Also shrinks the GitHub release archives and speeds release builds.
- **`build.ts`: `files` allowlist** (binary + `RELEASE_NOTES.md`) on each platform package manifest — defense-in-depth so a platform tarball can only ever contain the executable, regardless of stray files in `dist/<pkg>/bin/`.

## Verification

- `npm pack --dry-run` on a synthetic platform package confirms `.map` files are excluded by the allowlist.
- `tsgo` typecheck clean.

Net: darwin-arm64 global install ~135 MB → ~98 MB. Ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)